### PR TITLE
Issue Tracker Link

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1538,6 +1538,10 @@ label[for=mergestreams]::before {
     font-size: 1.6rem;
 }
 
+.topRightControls a {
+	color: #000;
+}
+
 #ocUploadIssueButton {
     padding-left: 10px;
 }

--- a/index.html
+++ b/index.html
@@ -69,7 +69,11 @@
                         <div class="topRightControls">
                             <label title="Go to Opencast" id="ocOpenServerButton"><i class="fas fa-play-circle"></i></label>
                             <label title="Open Upload Settings" id="ocUploadSettingsOpenButton"><i class="fas fa-cog"></i></label>
-                            <label title="Report Issue" id="ocUploadIssueButton"><i class="fas fa-exclamation-circle"></i></label>
+                            <a href="https://github.com/elan-ev/opencast-studio/issues"
+                               title="Report Issue"
+                               id="ocUploadIssueButton">
+                                <i class="fas fa-exclamation-circle"></i>
+                            </a>
                             <a href=about.html title="About Opencast Studio"><i class="fas fa-question-circle"></i></a>
                         </div>
                         <input type="radio" name="desktop" class="hiddenCheck streamToggle" id="desktopstream" autocomplete="off" />

--- a/js/opencastuploader.js
+++ b/js/opencastuploader.js
@@ -203,10 +203,6 @@ function OpencastUploaderSettingsDialog() {
   this.openOcServerButton = document.getElementById('ocOpenServerButton');
   this.openOcServerButton.addEventListener('click', this.openOcServer.bind(this), false);
 
-  // Issue Button
-  this.issueButton = document.getElementById('ocUploadIssueButton');
-  this.issueButton.addEventListener('click', this.openIssuesPage.bind(this), false);
-
   // get all relevant HTML Elements
   this.toggleModalEl = document.getElementById('toggleOcUploadSettingsModal');
   this.saveOcUploadSettingsEl = document.getElementById('saveOcUploadSettings');
@@ -255,9 +251,6 @@ OpencastUploaderSettingsDialog.prototype = {
   constructor: OpencastUploaderSettingsDialog,
   show: function() {
     this.toggleModalEl.checked = true;
-  },
-  openIssuesPage: function() {
-    window.open('https://github.com/elan-ev/opencast-studio/issues');
   },
   openOcServer: function() {
     let serverUrl = this.getServerUrl();


### PR DESCRIPTION
Instead of using a click event, this patch makes studio to use a link
for the issue tracker icon to give users control over weather or not
it is opened in a new tab.

This fixes parts of #58

*I intentionally did not modify dist/ to prevent merge conflicts*