### PR TITLE
update labels to make consistent and reduce duplication

### DIFF
--- a/src/ui/upload-settings.js
+++ b/src/ui/upload-settings.js
@@ -38,13 +38,13 @@ function OpencastUploaderSettingsDialog(props) {
   return (
     <div className={props.className}>
       <header>
-        <h1>Configure Opencast Upload</h1>
+        <h1>Configure Upload To Opencast</h1>
       </header>
 
       <main>
         {error && <Notification isDanger>{error}</Notification>}
 
-        <FormField label="Opencast Server URL">
+        <FormField label="Server URL">
           <input
             name="serverUrl"
             value={settings.serverUrl}
@@ -66,7 +66,7 @@ function OpencastUploaderSettingsDialog(props) {
           />
         </FormField>
 
-        <FormField label="Opencast Username">
+        <FormField label="Username">
           <input
             name="loginName"
             value={settings.loginName}
@@ -77,7 +77,7 @@ function OpencastUploaderSettingsDialog(props) {
           />
         </FormField>
 
-        <FormField label="Opencast Password">
+        <FormField label="Password">
           <input
             name="loginPassword"
             value={settings.loginPassword}


### PR DESCRIPTION
Issue #87  Updates labels for the Configure Upload to Opencast settings to make more consistent and reduce duplication.

![image](https://user-images.githubusercontent.com/21050517/66791881-bedd9b00-eebb-11e9-9220-82eaedd024d2.png)
