### PR TITLE
fix: prevent hiding of notification after 3s

### DIFF
--- a/src/ui/recording-controls.js
+++ b/src/ui/recording-controls.js
@@ -161,7 +161,7 @@ class RecordingControls extends React.Component {
 
     if (title !== '' && presenter !== '') {
       this.handleDialogClose();
-      const { hide } = toast.loading(t('upload-notification'));
+      const { hide } = toast.loading(t('upload-notification'), { hideAfter: 0 });
       new OpencastAPI(this.props.uploadSettings).loginAndUpload(
         // recording,
         [this.state.desktopRecording, this.state.videoRecording],


### PR DESCRIPTION
Notifications using the cogo-toast lib auto hide after 3 seconds. The "loading" notification should not hide before the upload is done.

Closes #153