### PR TITLE
Add sentry integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1362,6 +1362,63 @@
         "warning": "^3.0.0"
       }
     },
+    "@sentry/browser": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.7.1.tgz",
+      "integrity": "sha512-K0x1XhsHS8PPdtlVOLrKZyYvi5Vexs9WApdd214bO6KaGF296gJvH1mG8XOY0+7aA5i2A7T3ttcaJNDYS49lzw==",
+      "requires": {
+        "@sentry/core": "5.7.1",
+        "@sentry/types": "5.7.1",
+        "@sentry/utils": "5.7.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/core": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.7.1.tgz",
+      "integrity": "sha512-AOn3k3uVWh2VyajcHbV9Ta4ieDIeLckfo7UMLM+CTk2kt7C89SayDGayJMSsIrsZlL4qxBoLB9QY4W2FgAGJrg==",
+      "requires": {
+        "@sentry/hub": "5.7.1",
+        "@sentry/minimal": "5.7.1",
+        "@sentry/types": "5.7.1",
+        "@sentry/utils": "5.7.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.7.1.tgz",
+      "integrity": "sha512-evGh323WR073WSBCg/RkhlUmCQyzU0xzBzCZPscvcoy5hd4SsLE6t9Zin+WACHB9JFsRQIDwNDn+D+pj3yKsig==",
+      "requires": {
+        "@sentry/types": "5.7.1",
+        "@sentry/utils": "5.7.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.7.1.tgz",
+      "integrity": "sha512-nS/Dg+jWAZtcxQW8wKbkkw4dYvF6uyY/vDiz/jFCaux0LX0uhgXAC9gMOJmgJ/tYBLJ64l0ca5LzpZa7BMJQ0g==",
+      "requires": {
+        "@sentry/hub": "5.7.1",
+        "@sentry/types": "5.7.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/types": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.7.1.tgz",
+      "integrity": "sha512-tbUnTYlSliXvnou5D4C8Zr+7/wJrHLbpYX1YkLXuIJRU0NSi81bHMroAuHWILcQKWhVjaV/HZzr7Y/hhWtbXVQ=="
+    },
+    "@sentry/utils": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.7.1.tgz",
+      "integrity": "sha512-nhirUKj/qFLsR1i9kJ5BRvNyzdx/E2vorIsukuDrbo8e3iZ11JMgCOVrmC8Eq9YkHBqgwX4UnrPumjFyvGMZ2Q==",
+      "requires": {
+        "@sentry/types": "5.7.1",
+        "tslib": "^1.9.3"
+      }
+    },
     "@styled-system/background": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@styled-system/background/-/background-5.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@fortawesome/react-fontawesome": "^0.1.7",
     "@mdx-js/react": "^1.5.1",
     "@reach/router": "^1.2.1",
+    "@sentry/browser": "^5.7.1",
     "@theme-ui/components": "^0.2.46",
     "axios": "^0.19.0",
     "cogo-toast": "^4.1.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,13 @@
 //; -*- mode: rjsx;-*-
 import React, { lazy, Suspense } from 'react';
 import ReactDOM from 'react-dom';
+import * as Sentry from '@sentry/browser'
+
 import './i18n';
 import * as serviceWorker from './serviceWorker';
 import Loading from './loading';
+
+Sentry.init({dsn: "https://66e6b4dc3d59463fa34272abcb5da6b1@sentry.virtuos.uos.de/4"});
 
 const App = lazy(() => import('./App'));
 


### PR DESCRIPTION
Pure client-side errors in JS  are difficult to reproduce. Often the issue reporters do not have the detailled error logs required.

In these circumstances it is useful to have an error monitoring tool like Sentry (see: https://sentry.io).

The ELAN e.V. does have such a self-hosted instance.

With this PR all JS errors get logged to that error monitoring solution.