### PR TITLE
Document browser support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,12 @@ If you prefer to run a local **development** server directly, you can use instea
 ```sh
 % npm run start
 ```
+
+Supported Browsers
+------------------
+
+The following browsers are officially supported:
+
+- On desktop: Firefox, Chrome, Edge
+- Android: Chrome and Firefox
+- iOS: Safari

--- a/package.json
+++ b/package.json
@@ -43,9 +43,13 @@
   },
   "browserslist": {
     "production": [
-      ">0.2%",
+      ">1%",
       "not dead",
-      "not op_mini all"
+      "not op_mini all",
+      "last 2 chrome version",
+      "last 2 firefox version",
+      "last 2 safari version",
+      "last 2 FirefoxAndroid version"
     ],
     "development": [
       "last 1 chrome version",


### PR DESCRIPTION
Closes #155 

The configuration in `package.json` is just relevant for Babel and does not mean we support all browsers included there. Currently the queries include IE11 as it still has roughly 1.5% market share. And as adding `"not ie 11"` does not shrink the production JS files, there is no point in doing so IMO.

