### PR TITLE
fix: use a basepath in the router and its links

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -75,6 +75,7 @@ function App(props) {
         />
 
         <Router
+          basepath={process.env.PUBLIC_URL}
           sx={{ flex: 1, display: 'flex', flexDirection: 'column', '& > *': { flexGrow: 1 } }}
         >
           <Studio

--- a/src/link.js
+++ b/src/link.js
@@ -1,0 +1,20 @@
+//; -*- mode: rjsx;-*-
+/** @jsx jsx */
+import { jsx } from 'theme-ui';
+
+import { Link as ReachLink } from '@reach/router';
+
+const BASE = process.env.PUBLIC_URL;
+
+const Link = ({ to = '', children, absolute, ...props }) => {
+  if (!absolute && to[0] === '/') {
+    to = BASE + to;
+  }
+  return (
+    <ReachLink {...props} to={to}>
+      {children}
+    </ReachLink>
+  );
+};
+
+export default Link

--- a/src/ui/about.js
+++ b/src/ui/about.js
@@ -1,8 +1,8 @@
 //; -*- mode: rjsx;-*-
 /** @jsx jsx */
 import { jsx, Styled } from 'theme-ui';
-import { Link } from '@reach/router';
 import { Box } from '@theme-ui/components';
+import Link from '../link';
 
 const Container = props => <Box sx={{ maxWidth: 960, mx: 'auto', px: 3 }} {...props} />;
 

--- a/src/ui/footer.js
+++ b/src/ui/footer.js
@@ -2,9 +2,9 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui';
 
-import { Link } from '@reach/router';
 import { useTranslation } from 'react-i18next';
 import { Box } from '@theme-ui/components';
+import Link from '../link';
 
 function Footer(props) {
   const { t } = useTranslation();

--- a/src/ui/impressum.js
+++ b/src/ui/impressum.js
@@ -2,7 +2,7 @@
 /** @jsx jsx */
 import { jsx, Styled } from 'theme-ui';
 
-import { Link } from '@reach/router';
+import Link from '../link';
 import { Box } from '@theme-ui/components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faGlobeEurope, faEnvelope, faPhone } from '@fortawesome/free-solid-svg-icons';

--- a/src/ui/opencast-header.js
+++ b/src/ui/opencast-header.js
@@ -3,7 +3,7 @@
 import { jsx } from 'theme-ui';
 
 import LanguagesChooser from './languages-chooser';
-import { Link } from '@reach/router';
+import Link from '../link';
 
 const BetaBubble = props => (
   <span

--- a/src/ui/toolbar.js
+++ b/src/ui/toolbar.js
@@ -3,7 +3,7 @@
 import { jsx } from 'theme-ui';
 
 import { useTranslation } from 'react-i18next';
-import { Link } from '@reach/router';
+import Link from '../link';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {


### PR DESCRIPTION
To install opencast-studio in a subdirectory of a webserver the app must be build using PUBLIC_URL (see CRA docs):

`PUBLIC_URL=/mysubdirectory npm run build`

The used router lib allows to set a basepath to all the routes. Unfortunately the current implementation of Link is not enough and has to be fixed (see https://github.com/reach/router/issues/78).

Otherwise this works as expected.

Closes #158 