### PR TITLE
fix: use MediaRecorder.isTypeSupported only if supported

### DIFF
--- a/src/recorder.js
+++ b/src/recorder.js
@@ -1,26 +1,28 @@
 import EventEmitter from './event-emitter';
 
+const findSupportedMimeType = list =>
+  'isTypeSupported' in MediaRecorder
+    ? list.find(mimeType => MediaRecorder.isTypeSupported(mimeType)) || ''
+    : '';
+
 class Recorder extends EventEmitter {
-  constructor(stream, chosenCodec) {
+  constructor(stream, mimeType) {
     super();
 
-    const _vidCodecs =
-      'isTypeSupported' in MediaRecorder
-        ? [
+    if (!mimeType) {
+      mimeType = stream.getVideoTracks().length
+        ? findSupportedMimeType([
             'video/webm;codecs="vp9,opus"',
             'video/webm;codecs="vp9.0,opus"',
             'video/webm;codecs="avc1"',
             'video/x-matroska;codecs="avc1"',
             'video/webm;codecs="vp8,opus"'
-          ].filter(codec => MediaRecorder.isTypeSupported(codec))
-        : ['video/webm;codecs="vp9,opus"'];
-
-    const _audioCodecs = ['audio/ogg;codecs=opus', 'audio/webm;codecs=opus'];
+          ])
+        : findSupportedMimeType(['audio/ogg;codecs=opus', 'audio/webm;codecs=opus']);
+    }
 
     const _recData = [];
-
-    chosenCodec = chosenCodec || stream.getVideoTracks().length ? _vidCodecs[0] : _audioCodecs[0];
-    this.recorder = new MediaRecorder(stream, { mimeType: chosenCodec });
+    this.recorder = new MediaRecorder(stream, { mimeType });
     this.recorder.ondataavailable = function(e) {
       if (e.data.size > 0) {
         _recData.push(e.data);

--- a/src/recorder.js
+++ b/src/recorder.js
@@ -4,17 +4,20 @@ class Recorder extends EventEmitter {
   constructor(stream, chosenCodec) {
     super();
 
-    let _vidCodecs = [
-      'video/webm;codecs="vp9,opus"',
-      'video/webm;codecs="vp9.0,opus"',
-      'video/webm;codecs="avc1"',
-      'video/x-matroska;codecs="avc1"',
-      'video/webm;codecs="vp8,opus"'
-    ].filter(codec => MediaRecorder.isTypeSupported(codec));
+    const _vidCodecs =
+      'isTypeSupported' in MediaRecorder
+        ? [
+            'video/webm;codecs="vp9,opus"',
+            'video/webm;codecs="vp9.0,opus"',
+            'video/webm;codecs="avc1"',
+            'video/x-matroska;codecs="avc1"',
+            'video/webm;codecs="vp8,opus"'
+          ].filter(codec => MediaRecorder.isTypeSupported(codec))
+        : ['video/webm;codecs="vp9,opus"'];
 
-    let _audioCodecs = ['audio/ogg;codecs=opus', 'audio/webm;codecs=opus'];
+    const _audioCodecs = ['audio/ogg;codecs=opus', 'audio/webm;codecs=opus'];
 
-    let _recData = [];
+    const _recData = [];
 
     chosenCodec = chosenCodec || stream.getVideoTracks().length ? _vidCodecs[0] : _audioCodecs[0];
     this.recorder = new MediaRecorder(stream, { mimeType: chosenCodec });


### PR DESCRIPTION
Some browsers (I am looking at you Safari v13) do not support MediaRecorder.isTypeSupported. So we just do not use it in this case.