### PR TITLE
Fix detection of screen capturing capabilities of the browser

### DIFF
--- a/src/ui/media-devices.js
+++ b/src/ui/media-devices.js
@@ -17,7 +17,19 @@ function startDisplayCapture(displayMediaOptions) {
 }
 
 function supportsDisplayCapture() {
-  return 'mediaDevices' in navigator && 'getDisplayMedia' in navigator.mediaDevices;
+  // Detecting whether display capture is supported is hard. There is currently
+  // no proper solution. See these two links for more information:
+  // - https://stackoverflow.com/q/58842831/2408867
+  // - https://github.com/w3c/mediacapture-screen-share/issues/127
+  //
+  // To work around this problem, we simply check if the browser runs on a
+  // mobile device. Currently, no mobile device/browser supports display
+  // capture. However, this will probably change in the future, so we have to
+  // revisit this issue again. This is tracked in this issue:
+  // https://github.com/elan-ev/opencast-studio/issues/204
+  return 'mediaDevices' in navigator
+    && 'getDisplayMedia' in navigator.mediaDevices
+    && !/Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
 }
 
 function startUserCapture(userMediaOptions) {


### PR DESCRIPTION
Closes #83 (At least I assume the issue was about hiding that option, as we can't do anything about mobile devices not supporting that feature.)

I tested this on Android Chrome & Firefox. Still needs to be tested on iOS, but since I don't own such a device, I have to do it on Monday in the office (if no one else tests this first).