### PR TITLE
Add Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+Security Policy
+===============
+
+Supported Versions
+------------------
+
+This project has a rolling release and we only support the latest state of the branches `master` and `production`.
+
+
+Reporting a Vulnerability
+-------------------------
+
+If you find a security vulnerability,
+please report it by sending a mail to opencast-support@elan-ev.de.
+We will discuss the problem internally and, if necessary, release a patched version as soon as possible.


### PR DESCRIPTION
This patch adds a simple security policy for Opencast Studio, explaining
which branches/versions are supported and how to report security issues.