### PR TITLE
fix: some browsers do not implement MediaRecorder

### DIFF
--- a/src/recorder.js
+++ b/src/recorder.js
@@ -1,7 +1,7 @@
 import EventEmitter from './event-emitter';
 
 const findSupportedMimeType = list =>
-  'isTypeSupported' in MediaRecorder
+  MediaRecorder && 'isTypeSupported' in MediaRecorder
     ? list.find(mimeType => MediaRecorder.isTypeSupported(mimeType)) || ''
     : '';
 


### PR DESCRIPTION
On iOS you have to enable support for MediaRecorder with an experimental switch. So we just have to be a bit more defensive to prevent a non-responding GUI.
Refs #84