### PR TITLE
Fix screen capture capabilities detection and rename "webcam" to "camera" on mobile devices

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,35 +7,13 @@
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Web site created using create-react-app" />
     <link rel="apple-touch-icon" href="opencast-studio-icon-192.png" />
-    <!--
-             manifest.json provides metadata used when your web app is installed on a
-             user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-        -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-             Notice the use of %PUBLIC_URL% in the tags above.
-             It will be replaced with the URL of the `public` folder during the build.
-             Only files inside the `public` folder can be referenced from the HTML.
-
-             Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-             work correctly both with client-side routing and a non-root public URL.
-             Learn how to configure a non-root public URL by running `npm run build`.
-        -->
     <title>Opencast Studio (beta)</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <!--
-             This HTML file is a template.
-             If you open it directly in the browser, you will see an empty page.
 
-             You can add webfonts, meta tags, or analytics to this file.
-             The build step will place the bundled scripts into the <body> tag.
-
-             To begin the development, run `npm start` or `yarn start`.
-             To create a production bundle, use `npm run build` or `yarn build`.
-        -->
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-120509325-1"></script>
     <script>

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -17,7 +17,7 @@
   "save-creation-label-title": "Titel",
   "save-creation-modal-title": "Produktionsdetails",
   "share-desktop": "Bildschirm teilen",
-  "share-webcam": "Webcam teilen",
+  "share-camera": "Kamera teilen",
   "state-paused": "Pause",
   "state-recording": "Aufnahme",
   "state-waiting": "Warten",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -17,7 +17,7 @@
   "save-creation-label-title": "Title",
   "save-creation-modal-title": "Production Details",
   "share-desktop": "Share desktop",
-  "share-webcam": "Share webcam",
+  "share-camera": "Share camera",
   "state-paused": "Paused",
   "state-recording": "Recording",
   "state-waiting": "Waiting",

--- a/src/ui/media-devices.js
+++ b/src/ui/media-devices.js
@@ -77,7 +77,7 @@ function MediaDevices(props) {
       {isUserCaptureSupported() && (
         <MediaDevice
           onClick={requestUserMedia}
-          title={t('share-webcam')}
+          title={t('share-camera')}
           deviceType="video"
           icon={faVideo}
           stream={props.videoStream}

--- a/src/ui/media-devices.js
+++ b/src/ui/media-devices.js
@@ -6,6 +6,10 @@ import toast from 'cogo-toast';
 import { faDesktop, faVideo } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import MediaDevice from './media-device';
+import {
+  isDisplayCaptureSupported,
+  isUserCaptureSupported,
+} from "../util";
 import Notification from './notification';
 
 function startDisplayCapture(displayMediaOptions) {
@@ -16,10 +20,6 @@ function startDisplayCapture(displayMediaOptions) {
   });
 }
 
-function supportsDisplayCapture() {
-  return 'mediaDevices' in navigator && 'getDisplayMedia' in navigator.mediaDevices;
-}
-
 function startUserCapture(userMediaOptions) {
   const userMediaPromise = navigator.mediaDevices.getUserMedia(userMediaOptions);
 
@@ -28,10 +28,6 @@ function startUserCapture(userMediaOptions) {
     toast.error('Your browser does not permit to capture your webcam.');
     return null;
   });
-}
-
-function supportsUserCapture() {
-  return 'mediaDevices' in navigator && 'getUserMedia' in navigator.mediaDevices;
 }
 
 function MediaDevices(props) {
@@ -68,7 +64,7 @@ function MediaDevices(props) {
         }
       }}
     >
-      {supportsDisplayCapture() && (
+      {isDisplayCaptureSupported() && (
         <MediaDevice
           onClick={requestDisplayMedia}
           title={t('share-desktop')}
@@ -78,7 +74,7 @@ function MediaDevices(props) {
         />
       )}
 
-      {supportsUserCapture() && (
+      {isUserCaptureSupported() && (
         <MediaDevice
           onClick={requestUserMedia}
           title={t('share-webcam')}
@@ -88,7 +84,7 @@ function MediaDevices(props) {
         />
       )}
 
-      {!supportsDisplayCapture() && !supportsUserCapture() && (
+      {!isDisplayCaptureSupported() && !isUserCaptureSupported() && (
         <div sx={{ p: 3 }}>
           <Notification isDanger>
             Your browser does not allow capturing your display or any other media input.

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,30 @@
+// Checks if we app is running on a mobile device.
+//
+// This check could be more exhaustive, but this includes all browser we
+// officially support.
+export const onMobileDevice = () =>
+  /Android|iPhone|iPad|iPod/i.test(navigator.platform) ||
+  /Android/i.test(navigator.userAgent);
+
+// Checks if the client supports capturing the device's display (or individual
+// windows).
+//
+// Detecting whether display capture is supported is hard. There is currently
+// no proper solution. See these two links for more information:
+// - https://stackoverflow.com/q/58842831/2408867
+// - https://github.com/w3c/mediacapture-screen-share/issues/127
+//
+// To work around this problem, we simply check if the browser runs on a
+// mobile device. Currently, no mobile device/browser supports display
+// capture. However, this will probably change in the future, so we have to
+// revisit this issue again. This is tracked in this issue:
+// https://github.com/elan-ev/opencast-studio/issues/204
+export const isDisplayCaptureSupported = () =>
+  "mediaDevices" in navigator &&
+  "getDisplayMedia" in navigator.mediaDevices &&
+  !onMobileDevice();
+
+// Checks if the client supports capturing "user devices" (usually webcams or
+// phone cameras).
+export const isUserCaptureSupported = () =>
+  'mediaDevices' in navigator && 'getUserMedia' in navigator.mediaDevices;


### PR DESCRIPTION
Fixes #210 
Fixes #83 

Those commits were already created before learning about your preference to have one PR per issue fix. They are semi-connected though so I combined them all in this PR. Reviewing the commits individually might be useful tho.

Regarding testing screen recording capabilities: I tested this on Safari IOS, Android Firefox & Chrome and on Desktop Firefox.