### PR TITLE
Build date in test deployment

### DIFF
--- a/.travis-deploy-test.sh
+++ b/.travis-deploy-test.sh
@@ -21,8 +21,9 @@ else
   srcbranch="pull-request-${TRAVIS_PULL_REQUEST}"
 fi
 srcpath="$(pwd)"
+builddate="$(date --utc '+%Y%m%d%H%M%S')"
 buildno="$(printf '%06d' "${TRAVIS_BUILD_NUMBER}")"
-deploydir="build-${TRAVIS_REPO_SLUG}-${buildno}-${srcbranch}"
+deploydir="build-${builddate}-${TRAVIS_REPO_SLUG}-${buildno}-${srcbranch}"
 deploydir="$(echo "${deploydir}" | sed 's/[^a-Z0-9]/-/g')"
 export PUBLIC_URL="/${deploydir}"
 npm ci


### PR DESCRIPTION
This patch adds a build date to the test deployment so that builds from
different repositories are still in a sensible order.

Example: [/build-20191119230843-lkiesow-opencast-studio-000017-build-date-in-deployment](https://test.studio.opencast.org/build-20191119230843-lkiesow-opencast-studio-000017-build-date-in-deployment/)