### PR TITLE
refactor: move colors into theme definition

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,17 +1,13 @@
 //; -*- mode: rjsx;-*-
 /** @jsx jsx */
-import PropTypes from 'prop-types';
+import { jsx } from 'theme-ui';
 
-import { jsx, ThemeProvider } from 'theme-ui';
 import { Box, Flex } from '@theme-ui/components';
-
-import { Global } from '@emotion/core';
-import { BrowserRouter as Router, Switch, Redirect, Route } from 'react-router-dom';
+import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
+import { BrowserRouter as Router, Switch, Redirect, Route } from 'react-router-dom';
 
 import languages from './languages';
-import GlobalStyle from './style/global-style';
-import theme from './theme';
 import useLocalStorage from './use-local-storage';
 import initial from './default-settings';
 
@@ -38,8 +34,6 @@ function App({ defaultSettings = initial }) {
   };
 
   return (
-    <ThemeProvider theme={theme}>
-      <Global styles={GlobalStyle} />
       <Router basename={process.env.PUBLIC_URL || '/'}>
         <Flex
           sx={{
@@ -74,7 +68,6 @@ function App({ defaultSettings = initial }) {
           </Box>
         </Flex>
       </Router>
-    </ThemeProvider>
   );
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,12 @@
 //; -*- mode: rjsx;-*-
 import React, { lazy, Suspense } from 'react';
+import { Global } from '@emotion/core';
 import ReactDOM from 'react-dom';
 import * as Sentry from '@sentry/browser';
+import { ThemeProvider } from 'theme-ui';
+
+import GlobalStyle from './style/global-style';
+import theme from './theme';
 
 import './i18n';
 import * as serviceWorker from './serviceWorker';
@@ -12,11 +17,14 @@ Sentry.init({ dsn: 'https://66e6b4dc3d59463fa34272abcb5da6b1@sentry.virtuos.uos.
 const App = lazy(() => import('./App'));
 
 ReactDOM.render(
-  <Suspense fallback={<Loading />}>
-    <React.StrictMode>
-      <App />
-    </React.StrictMode>
-  </Suspense>,
+  <React.StrictMode>
+    <ThemeProvider theme={theme}>
+      <Global styles={GlobalStyle} />
+      <Suspense fallback={<Loading />}>
+        <App />
+      </Suspense>
+    </ThemeProvider>
+  </React.StrictMode>,
   document.getElementById('root')
 );
 

--- a/src/loading.js
+++ b/src/loading.js
@@ -1,36 +1,103 @@
 //; -*- mode: rjsx;-*-
 /** @jsx jsx */
-import { jsx } from 'theme-ui';
-import css from '@emotion/css/macro';
+import { jsx, useThemeUI } from 'theme-ui';
+import { keyframes } from '@emotion/core';
+
+const spin = keyframes`
+ 0% {
+    transform: rotate(0);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+`;
+
+const circleCover = keyframes`
+  0% {
+    stroke-dashoffset: 0;
+    transform: rotateX(180deg) rotateZ(90deg);
+  }
+  50% {
+    stroke-dashoffset: 515;
+    transform: rotateX(180deg) rotateZ(90deg);
+  }
+  50.01% {
+    transform: rotateX(0deg) rotateZ(-90deg);
+  }
+  100% {
+    stroke-dashoffset: 0;
+    transform: rotateX(0deg) rotateZ(-90deg);
+  }
+`;
 
 const Loading = () => {
+  const { theme } = useThemeUI();
+
   return (
     <div
-      css={css`
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-        text-align: center;
-        width: 12rem;
-        height: 12rem;
-        transition: opacity 0.5s 0.5s, visibility 0s 1s;
-      `}
+      sx={{
+        position: 'absolute',
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+        textAlign: 'center',
+        width: '12rem',
+        height: '12rem',
+        transition: 'opacity 0.5s 0.5s, visibility 0s 1s'
+      }}
     >
+      <svg
+        width="192"
+        height="192"
+        sx={{
+          width: '100%',
+          height: '100%',
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          zIndex: 1,
+          opacity: 1,
+          animation: `${spin} 6s infinite linear`
+        }}
+      >
+        <circle
+          r="82"
+          cx="96"
+          cy="96"
+          fill="none"
+          stroke={theme.colors.primary}
+          strokeWidth="8"
+          strokeDashoffset="0"
+          strokeDasharray="515"
+        ></circle>
+        <circle
+          r="82"
+          cx="96"
+          cy="96"
+          fill="none"
+          stroke="white"
+          strokeWidth="14"
+          strokeDashoffset="20"
+          strokeDasharray="515"
+          sx={{
+            animation: `${circleCover} 3s infinite linear`,
+            transformOrigin: '50% 50%'
+          }}
+        ></circle>
+      </svg>{' '}
       <span
-        css={css`
-          text-align: center;
-          position: absolute;
-          max-width: 80%;
-          max-height: 80%;
-          transform: translate(-50%, -50%);
-          top: 50%;
-          left: 50%;
-          position: absolute;
-          font-style: italic;
-          font-size: 1.25rem;
-          color: #666;
-        `}
+        sx={{
+          textAlign: 'center',
+          position: 'absolute',
+          maxWidth: '80%',
+          maxHeight: '80%',
+          transform: 'translate(-50%, -50%)',
+          top: '50%',
+          left: '50%',
+          fontStyle: 'italic',
+          fontSize: '1.25rem',
+          color: 'gray.1'
+        }}
       >
         Loading...
       </span>

--- a/src/style/global-style.js
+++ b/src/style/global-style.js
@@ -28,20 +28,6 @@ button {
     outline: none;
 }
 
-input {
-    border: 1px solid #ccc;
-    height: 2rem;
-    border-radius: 0.125rem;
-    padding: 0 0.5rem;
-    outline: none;
-    transition: border-color 0.3s, box-shadow 0.3s;
-}
-
-input:focus {
-    border-color: #47af7a;
-    box-shadow: 0 0 3px #8cf;
-}
-
 #root {
   height: 100%;
 }

--- a/src/theme.js
+++ b/src/theme.js
@@ -27,7 +27,9 @@ const base = {
     background: '#fff',
     primary: '#47af7a',
     secondary: '#30c',
-    muted: '#f6f6f6'
+    muted: '#f6f6f6',
+    error: '#f14668',
+    gray: ['#363636', '#666666', '#aaaaaa', '#dddddd']
   },
   buttons: {
     primary: {
@@ -107,6 +109,26 @@ const base = {
     },
     img: {
       maxWidth: '100%'
+    },
+    input: {
+      borderWidth: 1,
+      borderStyle: 'solid',
+      borderColor: 'gray.2',
+      height: '2rem',
+      borderRadius: 2,
+      px: 2,
+      py: 0,
+      outline: 'none',
+      transition: 'border-color 0.3s, box-shadow 0.3s',
+      width: '100%',
+      '&:focus': {
+        borderColor: 'primary',
+        boxShadow: theme => `0 0 3px 0 ${theme.colors.primary}`
+      },
+      '&[aria-invalid="true"]': {
+        borderColor: 'error',
+        boxShadow: theme => `0 0 3px 0 ${theme.colors.error}`
+      }
     }
   }
 };

--- a/src/ui/about.js
+++ b/src/ui/about.js
@@ -11,10 +11,13 @@ const Container = props => <Box sx={{ maxWidth: 960, mx: 'auto', px: 3 }} {...pr
 const Code = props => (
   <Box
     sx={{
-      background: '#f4f4f4',
-      color: '#666',
-      border: '1px solid #ddd',
-      borderLeft: '3px solid #f36d33',
+      background: 'gray.2',
+      color: 'gray.1',
+      borderWidth: 1,
+      borderStyle: 'solid',
+      borderColor: 'gray.2',
+      borderLeftWidth: 3,
+      borderLeftColor: 'primary',
       fontFamily: 'monospace',
       lineHeight: 'body',
       my: 3,
@@ -28,7 +31,6 @@ const Code = props => (
     {...props}
   />
 );
-
 
 function Impressum() {
   return (

--- a/src/ui/form-field.js
+++ b/src/ui/form-field.js
@@ -13,7 +13,7 @@ function FormField(props) {
     >
       <label
         sx={{
-          color: '#363636',
+          color: 'gray.0',
           display: 'block',
           fontSize: 2,
           fontWeight: 'bold'

--- a/src/ui/media-device.js
+++ b/src/ui/media-device.js
@@ -15,7 +15,7 @@ function MediaDevice({ onClick, title, icon, stream }) {
       onClick={stream ? null : onClick}
       data-title={title}
       sx={{
-        background: '#ddd',
+        backgroundColor: 'gray.3',
         boxShadow: '0 2px 2px rgba(0, 0, 0, 0.35)',
         overflow: 'hidden',
         zIndex: '0',
@@ -34,11 +34,11 @@ function MediaDevice({ onClick, title, icon, stream }) {
         sx={{
           outline: 'none',
           position: 'absolute',
-          top: '0',
-          left: '0',
+          top: 0,
+          left: 0,
           width: '100%',
           height: '100%',
-          zIndex: '2',
+          zIndex: 2,
           background: 'transparent'
         }}
       ></video>
@@ -55,7 +55,7 @@ function MediaDevice({ onClick, title, icon, stream }) {
           >
           <FontAwesomeIcon icon={icon} sx={{ fontSize: [6, 7, 8] }} />
           </span>
-          <p sx={{ color: '#666', fontSize: '1.5rem', fontWeight: '300' }}>{title}</p>
+          <p sx={{ color: 'gray.1', fontSize: 4, fontWeight: 'heading' }}>{title}</p>
         </Fragment>
       )}
     </div>

--- a/src/ui/notification.js
+++ b/src/ui/notification.js
@@ -6,8 +6,8 @@ const Notification = ({isDanger, ...rest}) => (
   <div
     sx={{
       ':not(:last-child)': { marginBottom: '1.5rem' },
-      backgroundColor: isDanger ? '#ff3860' : 'whitesmoke',
-      color: isDanger ? '#fff' : 'currentColor',
+      backgroundColor: isDanger ? 'error' : 'gray.3',
+      color: isDanger ? 'background' : 'currentColor',
       borderRadius: 2,
       padding: 3,
       position: 'relative'

--- a/src/ui/opencast-header.js
+++ b/src/ui/opencast-header.js
@@ -13,10 +13,12 @@ const BetaBubble = props => (
       fontSize: '12pt',
       verticalAlign: 'top',
       display: ['none', 'inline'],
-      border: '1px solid #888',
-      borderRadius: '5px',
+      borderWidth: 1,
+      borderStyle: 'solid',
+      borderColor: 'gray.2',
+      borderRadius: 5,
       padding: '2px',
-      color: '#aaa'
+      color: 'gray.2'
     }}
     {...props}
   />
@@ -50,7 +52,7 @@ function OpencastHeader(props) {
       sx={{
         height: '3rem',
         lineHeight: '3rem',
-        background: '#333',
+        backgroundColor: 'gray.0',
         color: 'background',
         display: 'flex',
         justifyContent: 'space-between'

--- a/src/ui/recording-preview.js
+++ b/src/ui/recording-preview.js
@@ -10,7 +10,7 @@ const RecordingPreview = ({ deviceType, title, type, url }) => {
     width: '8rem',
     height: '4.5rem',
     position: 'relative',
-    background: '#ddd',
+    backgroundColor: 'gray.3',
     textAlign: 'center',
     padding: '0.5rem',
     margin: '0 0.5rem 0.5rem 0',

--- a/src/ui/recording-state.js
+++ b/src/ui/recording-state.js
@@ -10,7 +10,7 @@ const RecordingState = props => {
   return (
       <div sx={{ display: "flex", alignItems: 'center', visibility: props.recordingState === 'inactive' ? 'hidden' : 'visible' }}>
       <Clock recordingState={props.recordingState} />
-        <p sx={{ px: 2, color: props.recordingState === 'paused' ? '#aaa' : 'transparent' }}>
+        <p sx={{ px: 2, color: props.recordingState === 'paused' ? 'gray.1' : 'transparent' }}>
         {props.recordingState === 'recording'
           ? t('Recording')
           : props.recordingState === 'paused'

--- a/src/ui/save-creation.js
+++ b/src/ui/save-creation.js
@@ -12,7 +12,7 @@ import FormField from './form-field';
 import Notification from './notification';
 import RecordingPreview from './recording-preview';
 
-const Input = props => <input sx={{ width: '100%' }} {...props} />;
+const Input = props => <input sx={{ variant: 'styles.input' }} {...props} />;
 
 function SaveCreationDialog(props) {
   const { t } = useTranslation();

--- a/src/ui/settings-form.js
+++ b/src/ui/settings-form.js
@@ -19,7 +19,7 @@ const Input = ({ errors, label, name, register, required, type = 'text', ...rest
     >
       <label
         sx={{
-          color: '#363636',
+          color: 'text',
           display: 'block',
           fontSize: 2,
           fontWeight: 'bold'
@@ -42,7 +42,7 @@ const Input = ({ errors, label, name, register, required, type = 'text', ...rest
             autoComplete="off"
             name={name}
             ref={register({ required })}
-            sx={{ width: '100%', '&[aria-invalid="true"]': { borderColor: '#f14668' } }}
+            sx={{ variant: 'styles.input' }}
             type={type}
             {...rest}
           />
@@ -50,7 +50,7 @@ const Input = ({ errors, label, name, register, required, type = 'text', ...rest
             <p
               id={`${name}Error`}
               sx={{
-                color: '#f14668',
+                color: 'error',
                 fontSize: 1,
                 fontWeight: 'body',
                 mt: 1


### PR DESCRIPTION
Currently colors are defined over the whole place. This issue unifies all the used colors and defines them in the theme.

The color of the recording button is not defined there because it should always be the same presumably.

Closes #226.