### PR TITLE
Fix bug when using `useRef`

### DIFF
--- a/src/ui/media-device.js
+++ b/src/ui/media-device.js
@@ -8,7 +8,9 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 function MediaDevice({ onClick, title, deviceType, icon, stream }) {
   const videoRef = useRef();
   useEffect(() => {
-    videoRef.current.srcObject = stream;
+    if (videoRef.current) {
+      videoRef.current.srcObject = stream;
+    }
   });
   return (
     <div


### PR DESCRIPTION
The `current` value is initialized to the argument given to `useRef`.
Since nothing is given to that function, `current` is `undefined`.
Before accessing the `srcObject` property, we now just check if the
`current` field has been initialized already.

This change partially fixes the app in Edge: now at least the UI is
shown. There are still other bugs and one can't yet see the webcam
preview video.

(I know that we don't plan on supporting the current Edge, but this is still a bug and rather strange that it works on other browsers. React does not guarantee that `current` will be initialized before we access `srcObject`)