### PR TITLE
Fix bug when using `useRef` to set `video.srcObject`

### DIFF
--- a/src/ui/media-device.js
+++ b/src/ui/media-device.js
@@ -8,7 +8,9 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 function MediaDevice({ onClick, title, icon, stream }) {
   const videoRef = useRef();
   useEffect(() => {
-    videoRef.current.srcObject = stream;
+    if (videoRef.current && typeof stream != 'undefined') {
+      videoRef.current.srcObject = stream;
+    }
   });
   return (
     <div


### PR DESCRIPTION
The `current` value is initialized to the argument given to `useRef`.
Since nothing is given to that function, `current` is `undefined`.
Before accessing the `srcObject` property, we now just check if the
`current` field has been initialized already.

Additionally, when assigning to `srcObject`, Edge makes sure the value
is not `undefined` (which is the case until the user actually approved
capturing their camera). So on Edge this broke, while the other 
browsers just ignored that. With this change, Edge "works" in the 
beginning: it looks normal and you can even preview your camera image.
However, since `MediaRecorder` is not implemented, the user can't
record.