### PR TITLE
Add "supported browsers" table to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,23 @@ If you prefer to run a local **development** server directly, you can use instea
 Supported Browsers
 ------------------
 
-The following browsers are officially supported:
+The following table depicts the current state of browser support.
+Please note that Opencast Studio uses fairly new web technologies that are not yet (fully) supported by all browsers.
+That's usually the reason for why this app does not work on a particular browser/system.
+In the table, "(✔)" means partial support and/or major bugs are still present.
 
-- On desktop: Firefox, Chrome, Edge
-- Android: Chrome and Firefox
-- iOS: Safari
+| OS         | Browser    | Capture Camera | Capture Screen | Record | Notes |
+| ---------- | ---------- | -------------- | -------------- | ------ | ----- |
+| Win10 | Chrome 77  | ✔              | ✔              | ✔      |
+| Win10 | Firefox 68 | ✔              | ✔              | ✔      |
+| Win10 | Edge 44    | (✔) [#217](https://github.com/elan-ev/opencast-studio/issues/217) | ✘ | ✘ | See [#242](https://github.com/elan-ev/opencast-studio/issues/242)
+| Linux      | Chrome 77  | ✔              | ✔              | ✔      |
+| Linux      | Firefox 68 | ✔              | ✔              | ✔      |
+| MacOS      | Firefox 70 | ✔              | ✔              | ✔      |
+| MacOS      | Chrome 78  | ✔              | ✔              | ✔      | Video file does not allow seeking
+| MacOS      | Safari 13  | ✔              | ✘              | ✘      | Recording seems to fail due to unsupported MIME type
+| Android    | Firefox 68 | ✔              | ✘              | ✔      |
+| Android    | Chrome 78  | (✔) [#217](https://github.com/elan-ev/opencast-studio/issues/217) | ✘ | (✔) [#243](https://github.com/elan-ev/opencast-studio/issues/243) | Low frame rate, fairly unusable
+| iOS        | Safari     | (✔) [#217](https://github.com/elan-ev/opencast-studio/issues/217) | ✘ | (✔) [#84](https://github.com/elan-ev/opencast-studio/issues/84) | Video rotated by 180° in recording, requires enabling experimental feature in settings
+
+Browsers/systems not listed in this table are not currently tested by us, so they might or might not work.


### PR DESCRIPTION
I just checked all these browsers/OS combinations to finally figure out (for realz) what platforms we currently support.  I think this is a much better overview than what we had before. Only thing I could not test is MacOS.

And I know that "Linux" is not a very precise definition of operating system, but checking for different linux distributions would be madness IMO. I think it's fine to assume that the browsers work the same regardless of Linux flavor.

The data for Edge assumes #241 is merged.

[Rendered README](https://github.com/elan-ev/opencast-studio/blob/bbc0e3b2d5c4a3ed1c6e27b4e8cd0717b4de6eec/README.md)