### PR TITLE
Include Build Information

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
   "scripts": {
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "REACT_APP_GIT_SHA=$(git rev-parse --short HEAD) REACT_APP_BUILD_DATE=$(date --utc '+%Y-%m-%d') react-scripts start",
+    "build": "REACT_APP_GIT_SHA=$(git rev-parse --short HEAD) REACT_APP_BUILD_DATE=$(date --utc '+%Y-%m-%d') react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/src/ui/about.js
+++ b/src/ui/about.js
@@ -168,6 +168,20 @@ function About(props) {
         </ul>
         <br />
         <Impressum></Impressum>
+
+        <Styled.h2>Version</Styled.h2>
+        <Styled.p>
+          Build date {process.env.REACT_APP_BUILD_DATE || '?'},
+          commit{' '}
+          <Styled.a
+            aria-label="Git commit on GitHub"
+            href={"https://github.com/elan-ev/opencast-studio/commit/"
+                  + process.env.REACT_APP_GIT_SHA }
+            >
+            {process.env.REACT_APP_GIT_SHA || '?'}
+          </Styled.a>.
+        </Styled.p>
+
         <Box as="footer" sx={{ py: 3, textAlign: 'center' }}>
           <Link sx={{ variant: 'styles.a' }} to="/">
             ← Back to the Studio


### PR DESCRIPTION
This patch adds the build date and commit hash to the bottom of the
about page making it easy to check which version has been deployed.

This fixes #220

---

[Deployed here](https://test.studio.opencast.org/build-20191121232706-lkiesow-opencast-studio-000022-build-number)