### PR TITLE
Add two warnings for HTTP connections and if `MediaRecorder` is not supported

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -36,5 +36,7 @@
   "upload-settings-label-server-url": "Server URL",
   "upload-settings-label-workflow-id": "Workflow ID",
   "upload-settings-label-username": "Username",
-  "upload-settings-label-password": "Password"
+  "upload-settings-label-password": "Password",
+  "warning-recorder-not-supported": "Your browser does not support recording media streams.",
+  "warning-recorder-safari-hint": "For Safari on iOS, you can enable the experimental feature 'MediaRecorder' in settings."
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -37,6 +37,7 @@
   "upload-settings-label-workflow-id": "Workflow ID",
   "upload-settings-label-username": "Username",
   "upload-settings-label-password": "Password",
+  "warning-https": "Most browsers do not allow video capture over an unencrypted connection (HTTP). Please switch to HTTPS.",
   "warning-recorder-not-supported": "Your browser does not support recording media streams.",
   "warning-recorder-safari-hint": "For Safari on iOS, you can enable the experimental feature 'MediaRecorder' in settings."
 }

--- a/src/ui/studio.js
+++ b/src/ui/studio.js
@@ -8,6 +8,7 @@ import { Box, Flex } from '@theme-ui/components';
 import MediaDevices from './media-devices';
 import RecordingControls from './recording-controls';
 import Toolbar from './toolbar';
+import Warnings from './warnings';
 
 const defaultRecordingData = {
   title: '',
@@ -26,6 +27,8 @@ function Studio(props) {
           settings={props.settings}
         />
       </Box>
+
+      <Warnings />
 
       <MediaDevices
         desktopStream={desktopStream}

--- a/src/ui/warnings.js
+++ b/src/ui/warnings.js
@@ -1,8 +1,8 @@
 //; -*- mode: rjsx;-*-
 /** @jsx jsx */
-import { jsx, Styled } from 'theme-ui';
+import { jsx } from 'theme-ui';
 import React from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 import Notification from './notification';
 import {
@@ -11,8 +11,14 @@ import {
 } from "../util";
 
 // Conditionally shows a number of warnings to help the user identify problems.
-const Warnings = (props) => {
+const Warnings = () => {
   const { t } = useTranslation();
+
+  // We allow HTTP connections to localhost, as most browsers also seem to allow
+  // video capture in those cases.
+  const usingUnsecureConnection = window.location.protocol !== 'https:' &&
+    window.location.hostname !== "localhost" &&
+    window.location.hostname !== "127.0.0.1";
 
   return (
     <React.Fragment>
@@ -21,6 +27,14 @@ const Warnings = (props) => {
           <Notification isDanger>
             {t('warning-recorder-not-supported')}
             {onSafari() && ' ' + t('warning-recorder-safari-hint')}
+          </Notification>
+        </div>
+      )}
+
+      { usingUnsecureConnection && (
+        <div sx={{ p: 3 }}>
+          <Notification isDanger>
+            {t('warning-https')}
           </Notification>
         </div>
       )}

--- a/src/ui/warnings.js
+++ b/src/ui/warnings.js
@@ -1,0 +1,31 @@
+//; -*- mode: rjsx;-*-
+/** @jsx jsx */
+import { jsx, Styled } from 'theme-ui';
+import React from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+
+import Notification from './notification';
+import {
+  onSafari,
+  isRecordingSupported,
+} from "../util";
+
+// Conditionally shows a number of warnings to help the user identify problems.
+const Warnings = (props) => {
+  const { t } = useTranslation();
+
+  return (
+    <React.Fragment>
+      {!isRecordingSupported() && (
+        <div sx={{ p: 3 }}>
+          <Notification isDanger>
+            {t('warning-recorder-not-supported')}
+            {onSafari() && ' ' + t('warning-recorder-safari-hint')}
+          </Notification>
+        </div>
+      )}
+    </React.Fragment>
+  );
+};
+
+export default Warnings;

--- a/src/util.js
+++ b/src/util.js
@@ -28,3 +28,10 @@ export const isDisplayCaptureSupported = () =>
 // phone cameras).
 export const isUserCaptureSupported = () =>
   'mediaDevices' in navigator && 'getUserMedia' in navigator.mediaDevices;
+
+// Checks if the browsers supports the `MediaRecorder` API required to actually
+// record the media streams.
+export const isRecordingSupported = () => typeof(MediaRecorder) !== 'undefined';
+
+// Checks if this runs in Safari.
+export const onSafari = () => /Safari/i.test(navigator.userAgent);


### PR DESCRIPTION
See commit messages for more information.

Closes #245 
Closes #206 