### PR TITLE
Remove CNAME File

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-studio.opencast.org


### PR DESCRIPTION
This was used back when studio.opencast.org was served directly from the
master branch. Since it is not anymore, we don't need this any longer.