### PR TITLE
Fix "black video preview" bug in mobile Firefox

### DIFF
--- a/src/ui/recording-preview.js
+++ b/src/ui/recording-preview.js
@@ -38,6 +38,9 @@ const RecordingPreview = ({ deviceType, title, type, url }) => {
           transform: 'translate(-50%, -50%)'
         }}
         src={url}
+
+        // Without this, some browsers show a black video element instead of the first frame.
+        onCanPlay={e => e.target.currentTime = 0}
       ></video>
     </a>
   );


### PR DESCRIPTION
Fixes #74 

While debugging this, I found nothing wrong with the way the `<video>` is used currently. So it might be a bug in Firefox, but probably I'm missing something else still. This PR basically just contains a workaround, but I think it kind of makes sense. But if you think it's too hacky, we can of course not merge this.