### PR TITLE
Fix video event handler triggering itself in a loop

### DIFF
--- a/src/ui/recording-preview.js
+++ b/src/ui/recording-preview.js
@@ -25,6 +25,15 @@ const RecordingPreview = ({ deviceType, title, type, url }) => {
     );
   }
 
+   // Without this, some browsers show a black video element instead of the first frame.
+  let hasBeenReset = false;
+  const onCanPlayHandler = e => {
+    if (!hasBeenReset) {
+      e.target.currentTime = 0;
+      hasBeenReset = true;
+    }
+  };
+
   return (
     <a sx={style} target="_blank" download={downloadName} href={url} rel="noopener noreferrer">
       {deviceType}
@@ -38,9 +47,7 @@ const RecordingPreview = ({ deviceType, title, type, url }) => {
           transform: 'translate(-50%, -50%)'
         }}
         src={url}
-
-        // Without this, some browsers show a black video element instead of the first frame.
-        onCanPlay={e => e.target.currentTime = 0}
+        onCanPlay={onCanPlayHandler}
       ></video>
     </a>
   );


### PR DESCRIPTION
Fixes #287. The issue has been caused by #270. 

I am still not really happy about this "solution", but I guess I have to get used to "hacks" in webdev?

[Deployed here](https://test.studio.opencast.org/build-20191204144352-LukasKalbertodt-opencast-studio-000036-fix-preview-cpu-usage/)