### PR TITLE
Fix the scrollbar flashing when starting to record

### DIFF
--- a/src/ui/recording-buttons.js
+++ b/src/ui/recording-buttons.js
@@ -17,6 +17,7 @@ const Button = ({ large, ...rest }) => (
       backgroundColor: 'transparent',
       border: 'none',
       position: 'relative',
+      overflow: 'hidden',
       my: 0,
       mx: large ? '1rem' : '0.5rem',
       padding: large ? '0.5rem' : '0.25rem',


### PR DESCRIPTION
Fixes #286 

This is simply caused by rotating an SVG (which already caused CPU utilization problems). The SVG "canvas" is still rectangular and the corners of that rectangle overflowed its parent container, leading to the scrollbar for a short time.

[Deployed here](https://test.studio.opencast.org/build-20191204145044-LukasKalbertodt-opencast-studio-000037-fix-scrollbar/)