### PR TITLE
Use `select.onchange` instead of `option.onclick` to fix language selector

### DIFF
--- a/src/ui/languages-select.js
+++ b/src/ui/languages-select.js
@@ -9,10 +9,13 @@ const LanguagesSelect = () => {
   const { i18n } = useTranslation();
 
   return (
-    <select sx={{ variant: 'styles.select' }} defaultValue={i18n.language} >
+    <select
+      sx={{ variant: 'styles.select' }}
+      defaultValue={i18n.language}
+      onChange={e => i18n.changeLanguage(e.target.value)}
+    >
       {languages.map(language => (
         <option
-          onClick={i18n.changeLanguage.bind(i18n, language.short)}
           value={language.short}
           key={language.short}
         >


### PR DESCRIPTION
Fixes #295 
See commit message for more information.

[Deployed here](https://test.studio.opencast.org/build-20191205150525-LukasKalbertodt-opencast-studio-000038-fix-language-selector/)