### PR TITLE
Fix incorrect check for existence of variable

### DIFF
--- a/src/recorder.js
+++ b/src/recorder.js
@@ -1,7 +1,8 @@
 import EventEmitter from './event-emitter';
+import { isRecordingSupported } from './util';
 
 const findSupportedMimeType = list =>
-  MediaRecorder && 'isTypeSupported' in MediaRecorder
+  isRecordingSupported() && 'isTypeSupported' in MediaRecorder
     ? list.find(mimeType => MediaRecorder.isTypeSupported(mimeType)) || ''
     : '';
 

--- a/src/util.js
+++ b/src/util.js
@@ -31,7 +31,7 @@ export const isUserCaptureSupported = () =>
 
 // Checks if the browsers supports the `MediaRecorder` API required to actually
 // record the media streams.
-export const isRecordingSupported = () => typeof(MediaRecorder) !== 'undefined';
+export const isRecordingSupported = () => typeof MediaRecorder !== 'undefined';
 
 // Checks if this runs in Safari.
 export const onSafari = () => /Safari/i.test(navigator.userAgent);


### PR DESCRIPTION
Just a tiny fix. Just testing `MediaRecorder && ...` leads to `ReferenceError` in some browsers. It's now `typeof MediaRecorder !== 'undefined'`.