### PR TITLE
Improve codec/MIME-type selection

### DIFF
--- a/src/recorder.js
+++ b/src/recorder.js
@@ -1,23 +1,6 @@
-import { isRecordingSupported } from './util';
-
-const findSupportedMimeType = list =>
-  isRecordingSupported() && 'isTypeSupported' in MediaRecorder
-    ? list.find(mimeType => MediaRecorder.isTypeSupported(mimeType)) || ''
-    : '';
-
 export default class Recorder {
   constructor(stream, options = {}) {
-    const mimeType =
-      options.mimeType ||
-      (stream.getVideoTracks().length
-        ? findSupportedMimeType([
-            'video/webm;codecs="vp9,opus"',
-            'video/webm;codecs="vp9.0,opus"',
-            'video/webm;codecs="avc1"',
-            'video/x-matroska;codecs="avc1"',
-            'video/webm;codecs="vp8,opus"'
-          ])
-        : findSupportedMimeType(['audio/ogg;codecs=opus', 'audio/webm;codecs=opus']));
+    const mimeType = options.mimeType || undefined;
 
     const _recData = [];
     this.recorder = new MediaRecorder(stream, { mimeType });


### PR DESCRIPTION
Fixes #243 
Fixes #335 
CC #84 

This has several advantages and fixes a few things. It's probably a better default than having a list of arbitrary MIME-types and codecs that we choose from. The browser usually has way more knowledge to choose that.

This is still a **draft** PR as I need to test this on many devices to check if the browser-selected codec is fine.