### PR TITLE
Improve settings, OC connection warning and fix menu bug

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -33,7 +33,7 @@ function App({ settingsManager }) {
 
             <Switch>
               <Route path="/settings" exact>
-                <SettingsPage settingsManager={settingsManager} hasRecording={activeStep === 3}/>
+                <SettingsPage settingsManager={settingsManager} />
               </Route>
 
               <Route path="/about" exact>

--- a/src/App.js
+++ b/src/App.js
@@ -33,7 +33,7 @@ function App({ settingsManager }) {
 
             <Switch>
               <Route path="/settings" exact>
-                <SettingsPage settingsManager={settingsManager} />
+                <SettingsPage settingsManager={settingsManager} hasRecording={activeStep === 3}/>
               </Route>
 
               <Route path="/about" exact>

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -38,5 +38,5 @@
   "upload-settings-label-workflow-id": "Workflow-ID",
   "upload-settings-label-username": "Benutzername",
   "upload-settings-label-password": "Passwort",
-  "settings-back": "Zurück"
+  "settings-back-to-recording": "Zurück zur Aufnahme"
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -85,6 +85,6 @@
   "warning-https": "Most browsers do not allow video capture over an unencrypted connection (HTTP). Please switch to HTTPS.",
   "warning-recorder-not-supported": "Your browser does not support recording media streams.",
   "warning-recorder-safari-hint": "For Safari on iOS, you can enable the experimental feature 'MediaRecorder' in settings.",
-  "warning-missing-connection-settings": "Connection to Opencast is not configured: uploading is disabled. Please configure the connection in the settings.",
-  "settings-back": "Back"
+  "warning-missing-connection-settings": "Connection to Opencast is not configured: uploading is disabled. Please configure the connection in <1>the settings</1> (you won't lose your recording).",
+  "settings-back-to-recording": "Back to recording"
 }

--- a/src/ui/navigation.js
+++ b/src/ui/navigation.js
@@ -71,6 +71,7 @@ const NavElement = ({ target, children, icon, ...rest }) => {
 const Navigation = props => {
   const [isOpened, updateIsOpened] = useState(false);
   const toggleMenu = () => updateIsOpened(!isOpened);
+  const closeMenu = () => updateIsOpened(false);
   const { t } = useTranslation();
 
   return (
@@ -123,19 +124,19 @@ const Navigation = props => {
           scrollX: ['none', 'none', 'auto'],
         }}
       >
-        <NavElement target="/" icon={faVideo} onClick={toggleMenu}>
+        <NavElement target="/" icon={faVideo} onClick={closeMenu}>
           {t('nav-recording')}
         </NavElement>
-        <NavElement target="/settings" icon={faWrench} onClick={toggleMenu}>
+        <NavElement target="/settings" icon={faWrench} onClick={closeMenu}>
           {t('nav-settings')}
         </NavElement>
-        <NavElement target="/about" icon={faInfoCircle} onClick={toggleMenu}>
+        <NavElement target="/about" icon={faInfoCircle} onClick={closeMenu}>
           {t('nav-about')}
         </NavElement>
         <NavElement
           target="https://github.com/elan-ev/opencast-studio/issues"
           icon={faGithub}
-          onClick={toggleMenu}
+          onClick={closeMenu}
         >
           {t('nav-report-issue')}
         </NavElement>
@@ -143,7 +144,7 @@ const Navigation = props => {
 
       {/* A black, half-transparent overlay over the body */}
       {isOpened && <div
-        onClick={toggleMenu}
+        onClick={closeMenu}
         ref={n => n && (n.style.opacity = 1)}
         sx={{
           display: [isOpened ? 'block' : 'none', isOpened ? 'block' : 'none', 'none'],

--- a/src/ui/settings/opencast.js
+++ b/src/ui/settings/opencast.js
@@ -14,16 +14,20 @@ import { useState } from 'react';
 import OpencastAPI from '../../opencast-api';
 import Notification from '../notification';
 import { Input, SettingsSection} from './elements';
+import { useRecordingState } from '../../recording-context';
 
 
 
-function OpencastSettings({ settingsManager, hasRecording }) {
+function OpencastSettings({ settingsManager }) {
   const { t } = useTranslation();
   const [error, setError] = useState();
   const { errors, handleSubmit, register } = useForm({
     defaultValues: settingsManager.formValues().opencast
   });
   const [status, setStatus] = useState('initial');
+
+  const { recordings } = useRecordingState();
+  const hasRecording = recordings.length > 0;
 
   async function onSubmit(data) {
     try {
@@ -115,7 +119,9 @@ function OpencastSettings({ settingsManager, hasRecording }) {
               spin={status === 'testing'}
             /> }
             { hasRecording && status === 'saved' && (
-              <Link to="/" sx={{ ml: 3 }}>{t('settings-back-to-recording')}</Link>
+              <Link to="/" sx={{ ml: 3, variant: 'styles.a' }}>
+                {t('settings-back-to-recording')}
+              </Link>
             )}
           </footer>
         </form>

--- a/src/ui/settings/opencast.js
+++ b/src/ui/settings/opencast.js
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCheckCircle, faCircleNotch, faExclamationCircle } from "@fortawesome/free-solid-svg-icons";
 import useForm from 'react-hook-form';
+import { Link } from 'react-router-dom';
 import { Box, Button } from '@theme-ui/components';
 
 import { useState } from 'react';
@@ -16,7 +17,7 @@ import { Input, SettingsSection} from './elements';
 
 
 
-function OpencastSettings({ settingsManager }) {
+function OpencastSettings({ settingsManager, hasRecording }) {
   const { t } = useTranslation();
   const [error, setError] = useState();
   const { errors, handleSubmit, register } = useForm({
@@ -113,6 +114,9 @@ function OpencastSettings({ settingsManager }) {
               sx={{ ml: '10px', fontSize: '30px', verticalAlign: 'middle' }}
               spin={status === 'testing'}
             /> }
+            { hasRecording && status === 'saved' && (
+              <Link to="/" sx={{ ml: 3 }}>{t('settings-back-to-recording')}</Link>
+            )}
           </footer>
         </form>
       </Box>

--- a/src/ui/settings/opencast.js
+++ b/src/ui/settings/opencast.js
@@ -67,7 +67,7 @@ function OpencastSettings({ settingsManager }) {
 
   return (
     <SettingsSection title={t('upload-settings-modal-header')}>
-      <Box sx={{ maxWidth: 960, mx: 'auto' }}>
+      <Box>
         {error && <Notification isDanger>{error}</Notification>}
 
         <form onSubmit={handleSubmit(onSubmit)}>

--- a/src/ui/settings/page.js
+++ b/src/ui/settings/page.js
@@ -3,7 +3,7 @@
 import { jsx, Styled } from 'theme-ui';
 
 import { useTranslation } from 'react-i18next';
-import { Container } from '@theme-ui/components';
+import { Box } from '@theme-ui/components';
 
 import LanguageSettings from './language';
 import OpencastSettings from './opencast';
@@ -13,7 +13,7 @@ const SettingsPage = ({ settingsManager }) => {
   const { t } = useTranslation();
 
   return (
-    <Container sx={{ p: 3 }}>
+    <Box sx={{ width: '100%', maxWidth: 960, mx: 'auto', p: 3 }}>
       <header>
         <Styled.h1>{t('settings-header')}</Styled.h1>
       </header>
@@ -21,7 +21,7 @@ const SettingsPage = ({ settingsManager }) => {
       <LanguageSettings />
 
       <OpencastSettings settingsManager={settingsManager} />
-    </Container>
+    </Box>
   );
 };
 

--- a/src/ui/settings/page.js
+++ b/src/ui/settings/page.js
@@ -9,8 +9,7 @@ import LanguageSettings from './language';
 import OpencastSettings from './opencast';
 
 
-const SettingsPage = ({ settingsManager, hasRecording }) => {
-  console.log(hasRecording);
+const SettingsPage = ({ settingsManager }) => {
   const { t } = useTranslation();
 
   return (
@@ -21,7 +20,7 @@ const SettingsPage = ({ settingsManager, hasRecording }) => {
 
       <LanguageSettings />
 
-      <OpencastSettings settingsManager={settingsManager} hasRecording={hasRecording} />
+      <OpencastSettings settingsManager={settingsManager} />
     </Box>
   );
 };

--- a/src/ui/settings/page.js
+++ b/src/ui/settings/page.js
@@ -9,7 +9,8 @@ import LanguageSettings from './language';
 import OpencastSettings from './opencast';
 
 
-const SettingsPage = ({ settingsManager }) => {
+const SettingsPage = ({ settingsManager, hasRecording }) => {
+  console.log(hasRecording);
   const { t } = useTranslation();
 
   return (
@@ -20,7 +21,7 @@ const SettingsPage = ({ settingsManager }) => {
 
       <LanguageSettings />
 
-      <OpencastSettings settingsManager={settingsManager} />
+      <OpencastSettings settingsManager={settingsManager} hasRecording={hasRecording} />
     </Box>
   );
 };

--- a/src/ui/settings/page.test.js
+++ b/src/ui/settings/page.test.js
@@ -7,6 +7,7 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import OpencastAPI from '../../opencast-api';
 import SettingsPage from './page';
 import { SettingsManager } from '../../settings';
+import { Provider } from '../../recording-context';
 
 import theme from '../../theme';
 import { ThemeProvider } from 'theme-ui';
@@ -33,11 +34,13 @@ it('renders empty form with no settings', async () => {
   const settingsManager = new SettingsManager();
 
   const { getByText, getByLabelText } = render(
-    <Router>
-      <ThemeProvider theme={theme}>
-        <SettingsPage settingsManager={settingsManager} handleUpdate={mockUpdate} />
-      </ThemeProvider>
-    </Router>
+    <Provider>
+      <Router>
+        <ThemeProvider theme={theme}>
+          <SettingsPage settingsManager={settingsManager} handleUpdate={mockUpdate} />
+        </ThemeProvider>
+      </Router>
+    </Provider>
   );
 
   expect(getByText('settings-header')).toBeInTheDocument();
@@ -64,11 +67,13 @@ it('renders empty form with partial OC settings', async () => {
   });
 
   const { getByText, getByLabelText, queryByLabelText } = render(
-    <Router>
-      <ThemeProvider theme={theme}>
-        <SettingsPage settingsManager={settingsManager} handleUpdate={mockUpdate} />
-      </ThemeProvider>
-    </Router>
+    <Provider>
+      <Router>
+        <ThemeProvider theme={theme}>
+          <SettingsPage settingsManager={settingsManager} handleUpdate={mockUpdate} />
+        </ThemeProvider>
+      </Router>
+    </Provider>
   );
 
   expect(getByText('settings-header')).toBeInTheDocument();
@@ -97,11 +102,13 @@ it('renders empty form with full OC settings', async () => {
   });
 
   const { getByText, queryByLabelText, queryByText } = render(
-    <Router>
-      <ThemeProvider theme={theme}>
-        <SettingsPage settingsManager={settingsManager} handleUpdate={mockUpdate} />
-      </ThemeProvider>
-    </Router>
+    <Provider>
+      <Router>
+        <ThemeProvider theme={theme}>
+          <SettingsPage settingsManager={settingsManager} handleUpdate={mockUpdate} />
+        </ThemeProvider>
+      </Router>
+    </Provider>
   );
 
   expect(getByText('settings-header')).toBeInTheDocument();

--- a/src/ui/studio/save-creation/index.js
+++ b/src/ui/studio/save-creation/index.js
@@ -183,7 +183,7 @@ export default function SaveCreation(props) {
         {!uploadPossible && (
           <Notification key="opencast-connection" isDanger>
             <Trans i18nKey="warning-missing-connection-settings">
-              Warning. <Link to="/settings">setting</Link>
+              Warning. <Link to="/settings" sx={{ variant: 'styles.a' }}>setting</Link>
             </Trans>
           </Notification>
         )}

--- a/src/ui/studio/save-creation/index.js
+++ b/src/ui/studio/save-creation/index.js
@@ -6,8 +6,9 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTrash, faUpload } from '@fortawesome/free-solid-svg-icons';
 import { Button, Box, Container, Spinner } from '@theme-ui/components';
 import { useReducer } from 'react';
+import { Link } from 'react-router-dom';
 import { Beforeunload } from 'react-beforeunload';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 import OpencastAPI from '../../../opencast-api';
 import { useRecordingState } from '../../../recording-context';
@@ -179,6 +180,14 @@ export default function SaveCreation(props) {
           }
         }}
       >
+        {!uploadPossible && (
+          <Notification key="opencast-connection" isDanger>
+            <Trans i18nKey="warning-missing-connection-settings">
+              Warning. <Link to="/settings">setting</Link>
+            </Trans>
+          </Notification>
+        )}
+
         <Button
           onClick={handleUpload}
           disabled={recordings.length === 0 || state.uploading || state.uploaded || !uploadPossible}

--- a/src/ui/warnings.js
+++ b/src/ui/warnings.js
@@ -4,7 +4,6 @@ import { jsx } from 'theme-ui';
 import { useTranslation } from 'react-i18next';
 
 import Notification from './notification';
-import OpencastAPI from '../opencast-api';
 import {
   onSafari,
   isRecordingSupported,
@@ -33,15 +32,6 @@ const Warnings = ({ settings }) => {
       <Notification key="media-recorder" isDanger>
         {t('warning-recorder-not-supported')}
         {onSafari() && ' ' + t('warning-recorder-safari-hint')}
-      </Notification>
-    );
-  }
-
-  // Warn if the user has not yet configured the Opencast connection
-  if (!OpencastAPI.areSettingsComplete(settings.opencast)) {
-    warnings.push(
-      <Notification key="opencast-connection" isDanger>
-        {t('warning-missing-connection-settings')}
       </Notification>
     );
   }


### PR DESCRIPTION
Fixes #375 

A few small things. Most importantly: the "no OC connection setting" is not shown everywhere anymore. Instead it is only shown in the post-recording dialog:

![Screenshot from 2020-01-28 14-25-40](https://user-images.githubusercontent.com/7419664/73269331-eba08e80-41dc-11ea-8e4f-c52fe723edd5.png)

When clicking the "settings" link in the warning or the menu, the settings page is shown. After the user saved and we validated an opencast connection, this is shown:

![Screenshot from 2020-01-28 14-26-15](https://user-images.githubusercontent.com/7419664/73269388-06730300-41dd-11ea-8f6b-58de6d7cb48a.png)

This special "back" link is only shown if the user already recorded something.

I would say this closes #373. But @lkiesow @luniki tell me if you are happy with this solution.
