### PR TITLE
Some adjustments to the video source selection page

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -42,7 +42,7 @@
   "sources-video-selection-done": "Display and/or camera is now shared. Select your audio source!",
   "sources-video-question": "What video source(s) to record?",
   "sources-video-none-available": "Your browser/device does not support capturing display or camera video :-(",
-  "sources-video-reselect-source": "Reselect source",
+  "sources-video-reselect-source": "Reselect source(s)",
 
   "sources-audio-selection-link": "Select audio",
   "sources-audio-selection-prompt": "Please share your audio source (or proceed without any audio)",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -39,6 +39,9 @@
   "sources-enter-studio-without-audio": "Proceed w/o audio",
 
   "sources-video-selection-prompt": "Please share your display and/or camera",
+  "sources-video-display-selected": "Display selected",
+  "sources-video-display-and-user-selected": "Display & Camera selected",
+  "sources-video-user-selected": "Camera selected",
   "sources-video-selection-done": "Display and/or camera is now shared. Select your audio source!",
   "sources-video-question": "What video source(s) to record?",
   "sources-video-none-available": "Your browser/device does not support capturing display or camera video :-(",

--- a/src/ui/studio/elements.js
+++ b/src/ui/studio/elements.js
@@ -8,8 +8,13 @@ import { Box, Button, Flex } from '@theme-ui/components';
 import { useTranslation } from 'react-i18next';
 
 // A div containing optional "back" and "next" buttons as well as the centered
-// children. The props `prev` and `next` are objects with the fields `onClick`
-// and `disabled`, both of which are forwarded to the `<Button>`.
+// children. The props `prev` and `next` are objects with the follwing fields:
+//
+// - `onClick`: forwarded to the `<Button>`
+// - `disabled`: forwarded to the `<Button>`
+// - `label` (optional): the button label translation string. If not specified,
+//   the label is 'back-button-label' or 'next-button-label'.
+// - `danger` (optional): forwarded to the `<Button>`, default: `false`.
 export function ActionButtons({ prev = null, next = null, children, sx }) {
   const { t } = useTranslation();
 
@@ -17,9 +22,17 @@ export function ActionButtons({ prev = null, next = null, children, sx }) {
     <Flex sx={{ alignItems: 'center', mt: 2 }}>
       <Box sx={{ flex: '1 1 0', textAlign: 'left' }}>
         {prev && (
-          <Button sx={{ whiteSpace: 'nowrap' }} onClick={prev.onClick} disabled={prev.disabled}>
+          <Button
+            sx={{
+              whiteSpace: 'nowrap',
+              ...prev.danger === true ? { variant: 'buttons.danger' } : {}
+            }}
+            onClick={prev.onClick}
+            disabled={prev.disabled}
+            danger={prev.danger || false}
+          >
             <FontAwesomeIcon icon={faCaretLeft} />
-            {t('back-button-label')}
+            {t(prev.label || 'back-button-label')}
           </Button>
         )}
       </Box>
@@ -27,11 +40,15 @@ export function ActionButtons({ prev = null, next = null, children, sx }) {
       <Box sx={{ flex: '1 1 0', textAlign: 'right' }}>
         {next && (
           <Button
-            sx={{ whiteSpace: 'nowrap', '& svg': { mr: 0, ml: 2 } }}
+            sx={{
+              whiteSpace: 'nowrap',
+              '& svg': { mr: 0, ml: 2 },
+              ...next.danger === true ? { variant: 'buttons.danger' } : {}
+            }}
             onClick={next.onClick}
             disabled={next.disabled}
           >
-            {t('next-button-label')}
+            {t(next.label || 'next-button-label')}
             <FontAwesomeIcon icon={faCaretRight} />
           </Button>
         )}

--- a/src/ui/studio/video-setup/index.js
+++ b/src/ui/studio/video-setup/index.js
@@ -88,9 +88,11 @@ export default function VideoSetup(props) {
 
   // The body depends on which source is currently selected.
   let hideUnshare;
+  let title;
   let body;
   switch (activeSource) {
     case NONE:
+      title = t('sources-video-question');
       hideUnshare = true;
       if (anySupported) {
         body = (
@@ -134,9 +136,9 @@ export default function VideoSetup(props) {
       break;
 
     case USER:
+      title = t('sources-video-user-selected');
       hideUnshare = !state.userStream && state.userAllowed !== false;
       body = <SourcePreview
-        title={t('source-user-title')}
         reselectSource={reselectSource}
         warnings={userWarning}
         inputs={[{ stream: state.userStream, allowed: state.userAllowed }]}
@@ -144,9 +146,9 @@ export default function VideoSetup(props) {
       break;
 
     case DISPLAY:
+      title = t('sources-video-display-selected');
       hideUnshare = !state.displayStream && state.displayAllowed !== false;
       body = <SourcePreview
-        title={t('source-display-title')}
         reselectSource={reselectSource}
         warnings={displayWarning}
         inputs={[{ stream: state.displayStream, allowed: state.displayAllowed }]}
@@ -154,10 +156,10 @@ export default function VideoSetup(props) {
       break;
 
     case BOTH:
+      title = t('sources-video-display-and-user-selected');
       hideUnshare = (!state.userStream && state.userAllowed !== false)
         || (!state.displayStream && state.displayAllowed !== false);
       body = <SourcePreview
-        title={t('source-display-and-user-title')}
         reselectSource={reselectSource}
         warnings={[displayWarning, userWarning]}
         inputs={[
@@ -181,7 +183,7 @@ export default function VideoSetup(props) {
       }}
     >
       <Styled.h1 sx={{ textAlign: 'center', fontSize: ['26px', '30px', '32px'] }}>
-        {t('sources-video-question')}
+        {title}
       </Styled.h1>
 
       { body }

--- a/src/ui/studio/video-setup/index.js
+++ b/src/ui/studio/video-setup/index.js
@@ -51,8 +51,8 @@ export default function VideoSetup(props) {
     await startUserCapture(dispatch, USER_CONSTRAINTS);
   };
   const clickDisplay = async () => {
-    await startDisplayCapture(dispatch);
     setActiveSource(DISPLAY);
+    await startDisplayCapture(dispatch);
   };
   const clickBoth = async () => {
     setActiveSource(BOTH);

--- a/src/ui/studio/video-setup/index.js
+++ b/src/ui/studio/video-setup/index.js
@@ -87,9 +87,11 @@ export default function VideoSetup(props) {
   );
 
   // The body depends on which source is currently selected.
+  let hideUnshare;
   let body;
   switch (activeSource) {
     case NONE:
+      hideUnshare = true;
       if (anySupported) {
         body = (
           <Flex
@@ -130,7 +132,9 @@ export default function VideoSetup(props) {
         body = <Notification isDanger>{t('sources-video-none-available')}</Notification>;
       }
       break;
+
     case USER:
+      hideUnshare = !state.userStream && state.userAllowed !== false;
       body = <SourcePreview
         title={t('source-user-title')}
         reselectSource={reselectSource}
@@ -138,7 +142,9 @@ export default function VideoSetup(props) {
         inputs={[{ stream: state.userStream, allowed: state.userAllowed }]}
       />;
       break;
+
     case DISPLAY:
+      hideUnshare = !state.displayStream && state.displayAllowed !== false;
       body = <SourcePreview
         title={t('source-display-title')}
         reselectSource={reselectSource}
@@ -146,8 +152,10 @@ export default function VideoSetup(props) {
         inputs={[{ stream: state.displayStream, allowed: state.displayAllowed }]}
       />;
       break;
+
     case BOTH:
-      // body = <DisplayAndUserMedia onReselect={reselectSource} />;
+      hideUnshare = (!state.userStream && state.userAllowed !== false)
+        || (!state.displayStream && state.displayAllowed !== false);
       body = <SourcePreview
         title={t('source-display-and-user-title')}
         reselectSource={reselectSource}
@@ -178,7 +186,15 @@ export default function VideoSetup(props) {
 
       { body }
 
-      <ActionButtons next={{ onClick: () => props.nextStep(), disabled: nextDisabled }} />
+      <ActionButtons
+        next={{ onClick: () => props.nextStep(), disabled: nextDisabled }}
+        prev={hideUnshare ? null : {
+          onClick: reselectSource,
+          disabled: false,
+          label: 'sources-video-reselect-source',
+          danger: true,
+        }}
+      />
     </Container>
   );
 }

--- a/src/ui/studio/video-setup/index.js
+++ b/src/ui/studio/video-setup/index.js
@@ -87,13 +87,13 @@ export default function VideoSetup(props) {
   );
 
   // The body depends on which source is currently selected.
-  let hideUnshare;
+  let hideActionButtons;
   let title;
   let body;
   switch (activeSource) {
     case NONE:
       title = t('sources-video-question');
-      hideUnshare = true;
+      hideActionButtons = true;
       if (anySupported) {
         body = (
           <Flex
@@ -137,7 +137,7 @@ export default function VideoSetup(props) {
 
     case USER:
       title = t('sources-video-user-selected');
-      hideUnshare = !state.userStream && state.userAllowed !== false;
+      hideActionButtons = !state.userStream && state.userAllowed !== false;
       body = <SourcePreview
         reselectSource={reselectSource}
         warnings={userWarning}
@@ -147,7 +147,7 @@ export default function VideoSetup(props) {
 
     case DISPLAY:
       title = t('sources-video-display-selected');
-      hideUnshare = !state.displayStream && state.displayAllowed !== false;
+      hideActionButtons = !state.displayStream && state.displayAllowed !== false;
       body = <SourcePreview
         reselectSource={reselectSource}
         warnings={displayWarning}
@@ -157,7 +157,7 @@ export default function VideoSetup(props) {
 
     case BOTH:
       title = t('sources-video-display-and-user-selected');
-      hideUnshare = (!state.userStream && state.userAllowed !== false)
+      hideActionButtons = (!state.userStream && state.userAllowed !== false)
         || (!state.displayStream && state.displayAllowed !== false);
       body = <SourcePreview
         reselectSource={reselectSource}
@@ -188,15 +188,15 @@ export default function VideoSetup(props) {
 
       { body }
 
-      <ActionButtons
+      { !hideActionButtons && <ActionButtons
         next={{ onClick: () => props.nextStep(), disabled: nextDisabled }}
-        prev={hideUnshare ? null : {
+        prev={{
           onClick: reselectSource,
           disabled: false,
           label: 'sources-video-reselect-source',
           danger: true,
         }}
-      />
+      />}
     </Container>
   );
 }

--- a/src/ui/studio/video-setup/preview.js
+++ b/src/ui/studio/video-setup/preview.js
@@ -4,18 +4,13 @@ import { jsx, Styled } from 'theme-ui';
 
 import { Fragment, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Box, Button, Card, Flex, Grid, Text, Spinner } from '@theme-ui/components';
+import { Button, Card, Flex, Grid, Text, Spinner } from '@theme-ui/components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faExclamationTriangle, faTimes } from '@fortawesome/free-solid-svg-icons';
 
 
 export function SourcePreview({ reselectSource, title, warnings, inputs }) {
   const { t } = useTranslation();
-
-  let hideUnshare = false;
-  for (const input of inputs) {
-    hideUnshare |= !input.stream && input.allowed !== false;
-  }
 
   let preview;
   switch (inputs.length) {
@@ -38,9 +33,6 @@ export function SourcePreview({ reselectSource, title, warnings, inputs }) {
     <Fragment>
       <Flex sx={{ alignItems: 'center', justifyContent: 'space-between' }}>
         <Styled.h2 sx={{ mt: 0 }}>{ title }</Styled.h2>
-        <Box>
-          { hideUnshare ? null : <UnshareButton handleClick={reselectSource} />}
-        </Box>
       </Flex>
 
       { warnings }

--- a/src/ui/studio/video-setup/preview.js
+++ b/src/ui/studio/video-setup/preview.js
@@ -1,15 +1,15 @@
 //; -*- mode: rjsx;-*-
 /** @jsx jsx */
-import { jsx, Styled } from 'theme-ui';
+import { jsx } from 'theme-ui';
 
 import { Fragment, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button, Card, Flex, Grid, Text, Spinner } from '@theme-ui/components';
+import { Button, Card, Grid, Text, Spinner } from '@theme-ui/components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faExclamationTriangle, faTimes } from '@fortawesome/free-solid-svg-icons';
 
 
-export function SourcePreview({ reselectSource, title, warnings, inputs }) {
+export function SourcePreview({ reselectSource, warnings, inputs }) {
   const { t } = useTranslation();
 
   let preview;
@@ -31,10 +31,6 @@ export function SourcePreview({ reselectSource, title, warnings, inputs }) {
 
   return (
     <Fragment>
-      <Flex sx={{ alignItems: 'center', justifyContent: 'space-between' }}>
-        <Styled.h2 sx={{ mt: 0 }}>{ title }</Styled.h2>
-      </Flex>
-
       { warnings }
       { preview }
     </Fragment>


### PR DESCRIPTION
Fixes #405
Fixes #401
Fixes #400
Fixes #394
Slightly improves #399

Move the "reselect sources" button to the bottom left, make it red, hide the "next" button when no video source is selected yet, improve the heading contents.

Since many requested this change, I already implemented it. We can take a look at this tomorrow and see if it's indeed an improvement. Draft PR as we want to discuss this before merging.

[**Deployed here**](https://test.studio.opencast.org/build-20200210172950-LukasKalbertodt-opencast-studio-000073-redesign-video-select/)