### PR TITLE
Use correct mime type for download link and blob object

### DIFF
--- a/src/recorder.js
+++ b/src/recorder.js
@@ -15,10 +15,11 @@ export default class Recorder {
     };
 
     this.recorder.onstop = () => {
-      const media = new Blob(_recData, { type: this.recorder.mimeType });
+      const mimeType = _recData[0].type || this.recorder.mimeType;
+      const media = new Blob(_recData, { type: mimeType });
       let url = URL.createObjectURL(media);
       this.recorder = null;
-      options.onStop && options.onStop({ url, media });
+      options.onStop && options.onStop({ url, media, mimeType });
     };
 
     this.isRecording = false;

--- a/src/ui/studio/recording/recording-controls.js
+++ b/src/ui/studio/recording/recording-controls.js
@@ -13,8 +13,8 @@ import { PauseButton, RecordButton, ResumeButton, StopButton } from './recording
 import Clock from './clock';
 
 function addRecordOnStop(dispatch, deviceType) {
-  return ({ media, url }) => {
-    dispatch({ type: 'ADD_RECORDING', payload: { deviceType, media, url } });
+  return ({ media, url, mimeType }) => {
+    dispatch({ type: 'ADD_RECORDING', payload: { deviceType, media, url, mimeType } });
   };
 }
 

--- a/src/ui/studio/save-creation/index.js
+++ b/src/ui/studio/save-creation/index.js
@@ -160,6 +160,7 @@ export default function SaveCreation(props) {
                 deviceType={recording.deviceType}
                 title={state.recordingData.title}
                 type="video"
+                mimeType={recording.mimeType}
                 url={recording.url}
               />
             ))

--- a/src/ui/studio/save-creation/recording-preview.js
+++ b/src/ui/studio/save-creation/recording-preview.js
@@ -6,9 +6,27 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faFileDownload } from '@fortawesome/free-solid-svg-icons';
 import { Box } from '@theme-ui/components';
 
-const RecordingPreview = ({ deviceType, title, type, url }) => {
+import { onSafari } from '../../../util.js';
+
+const RecordingPreview = ({ deviceType, title, type, url, mimeType }) => {
   const flavor = deviceType === 'desktop' ? 'Presentation' : 'Presenter';
-  const downloadName = `${flavor} ${type} - ${title || 'Recording'}.webm`;
+
+  // Determine the correct filename extension.
+  // TODO: we might want to parse the mime string in the future? But right now,
+  // browsers either record in webm or mp4.
+  let fileExt;
+  if (mimeType && mimeType.startsWith("video/webm")) {
+    fileExt = "webm";
+  } else if (mimeType && mimeType.startsWith("video/mp4")) {
+    fileExt = "mp4";
+  } else if (onSafari()) {
+    // Safari does not understand webm
+    fileExt = "mp4";
+  } else {
+    // If we know nothing, our best guess is webm.
+    fileExt = "webm";
+  }
+  const downloadName = `${flavor} ${type} - ${title || 'Recording'}.${fileExt}`;
 
   const style = {
     width: '8rem',


### PR DESCRIPTION
Closes #202 
CC #84 

This means that Apple devices can download and play the file AND that
the `<video>` preview of the recording works.

This is "interesting": the media recorder itself does not expose the mime type (`mediaRecorder.mimeType` is an empty string), but in the raw recording data, the mime type is correctly set. I use this mime type now to set the mime type of the resulting blob object and to correctly figure out the filename extension for the download.