### PR TITLE
Make source select pages span entire height, moving buttons to bottom

### DIFF
--- a/src/ui/studio/audio-setup/index.js
+++ b/src/ui/studio/audio-setup/index.js
@@ -61,7 +61,8 @@ export default function AudioSetup(props) {
       sx={{
         display: 'flex',
         flexDirection: 'column',
-        flex: '1 0 auto',
+        flex: '1 1 auto',
+        justifyContent: 'space-between',
       }}
     >
       <Styled.h1 sx={{ textAlign: 'center' }}>{t('sources-audio-question')}</Styled.h1>

--- a/src/ui/studio/video-setup/index.js
+++ b/src/ui/studio/video-setup/index.js
@@ -103,10 +103,10 @@ export default function VideoSetup(props) {
               width: '100%',
               mx: ['auto', 'none'],
               mb: 3,
-              flex: ['0 1 auto', '1 1 auto'],
+              flex: '1 1 auto',
               maxHeight: ['none', '270px'],
               minHeight: [0, ''],
-              justifyContent: ['flex-start', 'center'],
+              justifyContent: 'center',
               '& > :not(:last-of-type)': {
                 mb: [3, 0],
                 mr: [0, 3],
@@ -186,7 +186,9 @@ export default function VideoSetup(props) {
         {title}
       </Styled.h1>
 
+      <Spacer />
       { body }
+      <Spacer />
 
       { !hideActionButtons && <ActionButtons
         next={{ onClick: () => props.nextStep(), disabled: nextDisabled }}
@@ -210,10 +212,11 @@ const OptionButton = ({ icon, label, onClick }) => {
         color: 'gray.0',
         border: '2px solid black',
         borderRadius: '8px',
-        flex: ['0 1 180px', '0 1 100%'],
+        flex: ['1 1 auto', '0 1 100%'],
         minWidth: '180px',
         maxWidth: '300px',
-        minHeight: ['120px', '150px'],
+        minHeight: '120px',
+        maxHeight: '250px',
         p: 2,
       }}
     >
@@ -224,3 +227,5 @@ const OptionButton = ({ icon, label, onClick }) => {
     </button>
   );
 };
+
+const Spacer = () => <div sx={{ flex: '1 0 0' }}></div>;


### PR DESCRIPTION
Fixes #397 

Based on #419, so merge that first.