### PR TITLE
Remove `.map` files in test deployment to reduce size

### DIFF
--- a/.travis-deploy-test.sh
+++ b/.travis-deploy-test.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+echo "Starting Test deployment script"
+
 # Immediately cancel if there is no deployment key
 if [ -z "${STUDIO_TEST_DEPLOY_KEY}" ]; then
   echo No deployment key. Canceling deployment.

--- a/.travis-deploy-test.sh
+++ b/.travis-deploy-test.sh
@@ -36,8 +36,9 @@ git clone "git@github.com:elan-ev/studio-test.git"
 cd studio-test
 git checkout gh-pages
 
-# Add new content
+# Add new content, but remove large '.map' files
 mv "${srcpath}/build/" "${deploydir}"
+rm "${deploydir}/static/js/*.map"
 
 # Build new index
 echo '<html><body><ul>' > index.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ jobs:
         - npm run build
         - npm test
 
-    # Deploy translation keys to Crowdin if we are on develop or one of the release branches
     - stage: deployment
       install: skip
       script: skip
@@ -20,7 +19,6 @@ jobs:
         on:
           branch: production
 
-    # Deploy translation keys to Crowdin if we are on develop or one of the release branches
     - stage: deployment
       install: skip
       script: skip


### PR DESCRIPTION
The test deploy repository grew fairly large. To reduce the size of
future deployments, CI now automatically removes the .map files which
take up roughly 75% of space of the deployed app.

I also already removed many old deployments manually.