### PR TITLE
Hide wizard if `MediaRecorder` is not available

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -101,7 +101,7 @@
 
   "warning-https": "Most browsers do not allow video capture over an unencrypted connection (HTTP). Please switch to HTTPS.",
   "warning-recorder-not-supported": "Your browser does not support recording media streams.",
-  "warning-recorder-safari-hint": "For Safari on iOS, you can enable the experimental feature 'MediaRecorder' in settings.",
+  "warning-recorder-safari-hint": "If you are using Safari, you can enable the experimental feature 'MediaRecorder' in settings. However, on MacOS, we recommend switching to Chrome or Firefox.",
   "warning-missing-connection-settings": "Connection to Opencast is not fully established: uploading is disabled. Please configure the connection in <1>the settings</1> (you won't lose your recording).",
   "settings-back-to-recording": "Back to recording"
 }

--- a/src/ui/studio/page.js
+++ b/src/ui/studio/page.js
@@ -10,8 +10,16 @@ import SaveCreation from './save-creation';
 import VideoSetup from './video-setup';
 import Recording from './recording';
 
+import {isRecordingSupported} from '../../util';
+
 export default function Wizard({ settings, activeStep, updateActiveStep }) {
   const [audioChoice, updateAudioChoice] = useState(NONE);
+
+  // If recording is not supported we don't even let the user start the wizard.
+  // A warning is shown already (in `warnings.js`).
+  if (!isRecordingSupported()) {
+    return null;
+  }
 
   return (
     <Fragment>


### PR DESCRIPTION
For some reason, Sentry reports many errors where `MediaRecorder` is
undefined. This only happens when people actually go through the wizard
and start recording on a browser that does not support `MediaRecorder`.
However, a big red warning is already shown in those cases. But
apparently users just ignore it. So now they can't even start
recording.