### PR TITLE
Remove countdown from recording page

### DIFF
--- a/src/ui/studio/recording/recording-controls.js
+++ b/src/ui/studio/recording/recording-controls.js
@@ -2,7 +2,7 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { Beforeunload } from 'react-beforeunload';
 import { useTranslation } from 'react-i18next';
 
@@ -35,8 +35,6 @@ export default function RecordingControls({
   const dispatch = useDispatch();
 
   const { audioStream, displayStream, userStream } = useRecordingState();
-
-  const [countdown, setCountdown] = useState(false);
 
   const desktopRecorder = useRef(null);
   const videoRecorder = useRef(null);
@@ -95,12 +93,8 @@ export default function RecordingControls({
     if (!hasStreams) {
       return;
     }
-    setCountdown(true);
-    setTimeout(() => {
-      setRecordingState(STATE_RECORDING);
-      setCountdown(false);
-      record();
-    }, 1000);
+    setRecordingState(STATE_RECORDING);
+    record();
   };
 
   const handleStop = () => {
@@ -141,7 +135,6 @@ export default function RecordingControls({
               recordingState={recordingState}
               onClick={handleRecord}
               disabled={!hasStreams}
-              countdown={countdown}
             />
           ) : (
             <StopButton


### PR DESCRIPTION
The current countdown is 1s long and does not have any indicator of "counting down". To be honest, until very recently I just thought that this delay was just because the `MediaRecorder` api needs some time to get started and a faster computer would improve this. This is clearly not good. 

Also, 1s is way too short to use the countdown in a reasonable way. A proper countdown would also need sound effects to indicate the state to the user even when the browser window is not in the front. 

Not having a countdown and not having a way to "cut" the video afterwards is not ideal. But having a useless countdown that just feels like lag is worse. So this is the easy solution for now.