### PR TITLE
Add script to create release artifacts

### DIFF
--- a/create-release.sh
+++ b/create-release.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Remove old 'build' folder
+if [ -d build ]; then
+  read -p "Will delete 'build/' folder. Is that OK? [y/N] " -r
+
+  if [[ ! $REPLY =~ ^[Yy]$ ]]
+  then
+    exit 1
+  else
+    rm -rf build
+  fi
+fi
+
+
+# Build version for root path installation
+export PUBLIC_URL=/
+npm run build
+rm build/static/js/*.map
+
+FILENAME="oc-studio-$(date --utc +%F)-root.tar.gz"
+cd build
+tar -czf ../$FILENAME *
+cd ..
+
+
+# Build version for root path installation
+rm -rf build/
+export PUBLIC_URL=/studio
+npm run build
+rm build/static/js/*.map
+
+FILENAME="oc-studio-$(date --utc +%F)-integrated.tar.gz"
+cd build
+tar -czf ../$FILENAME *
+cd ..
+
+
+# Delete our temporary folder at the end
+rm -rf build/


### PR DESCRIPTION
This will result in `oc-studio-2020-03-05-integrated.tar.gz` (the one deployed at `/studio`) and `oc-studio-2020-03-05-root.tar.gz` (deployed at root path).