### PR TITLE
Switch to more general mkv file extension

### DIFF
--- a/src/opencast.js
+++ b/src/opencast.js
@@ -266,7 +266,7 @@ export class Opencast {
         }
 
         const flavor = deviceType === 'desktop' ? 'Presentation' : 'Presenter';
-        const downloadName = `${flavor} - ${title || 'Recording'}.webm`;
+        const downloadName = `${flavor} - ${title || 'Recording'}.mkv`;
 
         const body = new FormData();
         body.append('mediaPackage', mediaPackage);

--- a/src/ui/studio/save-creation/recording-preview.js
+++ b/src/ui/studio/save-creation/recording-preview.js
@@ -15,7 +15,7 @@ const RecordingPreview = ({ deviceType, url, mimeType, onDownload, downloaded })
 
   // Determine the correct filename extension.
   // TODO: we might want to parse the mime string in the future? But right now,
-  // browsers either record in webm or mp4.
+  // browsers either record in webm/mkv or mp4.
   let fileExt;
   if (mimeType && mimeType.startsWith("video/webm")) {
     fileExt = "webm";
@@ -25,8 +25,8 @@ const RecordingPreview = ({ deviceType, url, mimeType, onDownload, downloaded })
     // Safari does not understand webm
     fileExt = "mp4";
   } else {
-    // If we know nothing, our best guess is webm.
-    fileExt = "webm";
+    // If we know nothing, our best guess is mkv.
+    fileExt = "mkv";
   }
   const downloadName = `oc-studio-${now_as_string()}-${flavor}.${fileExt}`;
 


### PR DESCRIPTION
I'm testing with `macOS 10.15.3` and Google Chrome `80.0.3987.132`.

My browser records with `h.264` and `opus` in a `Matroska` container:

<details>

```sh
❯ mediainfo presentation.mp4
General
Complete name                            : presentation.mp4
Format                                   : Matroska
Format version                           : Version 4
File size                                : 8.58 MiB
Writing application                      : Chrome
Writing library                          : Chrome
IsTruncated                              : Yes
FileExtension_Invalid                    : mkv mk3d mka mks

Video
ID                                       : 2
Format                                   : AVC
Format/Info                              : Advanced Video Codec
Codec ID                                 : V_MPEG4/ISO/AVC
Width                                    : 1 920 pixels
Height                                   : 1 176 pixels
Display aspect ratio                     : 16:10
Frame rate mode                          : Variable
Language                                 : English
Default                                  : Yes
Forced                                   : No

Audio
ID                                       : 1
Format                                   : Opus
Codec ID                                 : A_OPUS
Channel(s)                               : 1 channel
Channel layout                           : C
Sampling rate                            : 48.0 kHz
Bit depth                                : 32 bits
Compression mode                         : Lossy
Delay relative to video                  : 539 ms
Language                                 : English
Default                                  : Yes
Forced                                   : No

❯ ffprobe -hide_banner presentation.mp4
Input #0, matroska,webm, from 'presentation.mp4':
  Metadata:
    encoder         : Chrome
  Duration: N/A, start: 0.000000, bitrate: N/A
    Stream #0:0(eng): Audio: opus, 48000 Hz, mono, fltp (default)
    Stream #0:1(eng): Video: h264 (Baseline), yuv420p(progressive), 1920x1176 [SAR 1:1 DAR 80:49], 16.67 tbr, 1k tbn, 2k tbc (default)
```

</details>

When I download the recordings, `.mp4` is used as file extension (see #485). When I upload to Opencast `.webm` is used (seems to be hardcoded for all browsers in this case).

It is my understanding that WebM is a subset of Matroska and as such the supported features are limited. In particular `ffmpeg` reports that WebM **does not** support h.264. In our workflows we first rewrite the incoming video using the `prepare-av` operation to (among other things) set the correct timing information. The following `ffmpeg` command is executed for uploaded files:

```sh
❯ ffmpeg -nostdin -nostats -hide_banner \
>   -i presenter.webm \
>   -c:v copy \
>   -c:a copy \
>   presenter-rewrite.webm
Input #0, matroska,webm, from 'presenter.webm':
  Metadata:
    encoder         : Chrome
  Duration: N/A, start: 0.000000, bitrate: N/A
    Stream #0:0(eng): Audio: opus, 48000 Hz, mono, fltp (default)
    Stream #0:1(eng): Video: h264 (Baseline), yuv420p(progressive), 1280x720 [SAR 1:1 DAR 16:9], 16.67 fps, 16.67 tbr, 1k tbn, 2k tbc (default)
[webm @ 0x5555572ba580] Only VP8 or VP9 or AV1 video and Vorbis or Opus audio and WebVTT subtitles are supported for WebM.
Could not write header for output file #0 (incorrect codec parameters ?): Invalid argument
Stream mapping:
  Stream #0:1 -> #0:0 (copy)
  Stream #0:0 -> #0:1 (copy)
    Last message repeated 1 times
```

The limitation of WebM lead to an error. If the file extension is set to `.mkv`, `ffmpeg` will rewrite the file:

```sh
❯ ffmpeg -nostdin -nostats -hide_banner \
>   -i presenter.mkv \
>   -c:v copy \
>   -c:a copy \
>   presenter-rewrite.mkv
Input #0, matroska,webm, from 'presenter.mkv':
  Metadata:
    encoder         : Chrome
  Duration: N/A, start: 0.000000, bitrate: N/A
    Stream #0:0(eng): Audio: opus, 48000 Hz, mono, fltp (default)
    Stream #0:1(eng): Video: h264 (Baseline), yuv420p(progressive), 1280x720 [SAR 1:1 DAR 16:9], 16.67 fps, 16.67 tbr, 1k tbn, 2k tbc (default)
Output #0, matroska, to 'presenter-rewrite.mkv':
  Metadata:
    encoder         : Lavf58.41.100
    Stream #0:0(eng): Video: h264 (Baseline) (H264 / 0x34363248), yuv420p(progressive), 1280x720 [SAR 1:1 DAR 16:9], q=2-31, 16.67 fps, 16.67 tbr, 1k tbn, 1k tbc (default)
    Stream #0:1(eng): Audio: opus ([255][255][255][255] / 0xFFFFFFFF), 48000 Hz, mono, fltp (default)
Stream mapping:
  Stream #0:1 -> #0:0 (copy)
  Stream #0:0 -> #0:1 (copy)
frame=  650 fps=0.0 q=-1.0 Lsize=    4754kB time=00:00:21.66 bitrate=1798.0kbits/s speed= 160x
video:4611kB audio:135kB subtitle:0kB other streams:0kB global headers:0kB muxing overhead: 0.167362%
```

I suggest changing the file extension to the more general `.mkv`.