### PR TITLE
Fix file extension and Safari detection

### DIFF
--- a/src/opencast.js
+++ b/src/opencast.js
@@ -4,6 +4,8 @@ import { jsx } from 'theme-ui';
 import React, { useEffect, useState } from 'react';
 import equal from 'fast-deep-equal';
 
+import { recordingFileName } from './util.js';
+
 
 // The server URL was not specified.
 export const STATE_UNCONFIGURED = 'unconfigured';
@@ -257,7 +259,7 @@ export class Opencast {
         .then(response => response.text());
 
       // Add all recordings
-      for (const { deviceType, media } of recordings) {
+      for (const { deviceType, media, mimeType } of recordings) {
         let trackFlavor = 'presentation/source';
         if (deviceType === 'desktop') {
           trackFlavor = 'presentation/source';
@@ -265,8 +267,8 @@ export class Opencast {
           trackFlavor = 'presenter/source';
         }
 
-        const flavor = deviceType === 'desktop' ? 'Presentation' : 'Presenter';
-        const downloadName = `${flavor} - ${title || 'Recording'}.webm`;
+        const flavor = deviceType === 'desktop' ? 'presentation' : 'presenter';
+        const downloadName = recordingFileName(mimeType, flavor);
 
         const body = new FormData();
         body.append('mediaPackage', mediaPackage);

--- a/src/ui/studio/save-creation/recording-preview.js
+++ b/src/ui/studio/save-creation/recording-preview.js
@@ -7,28 +7,12 @@ import { faDownload, faCheckCircle } from '@fortawesome/free-solid-svg-icons';
 import { Button } from '@theme-ui/components';
 import { useTranslation } from 'react-i18next';
 
-import { onSafari } from '../../../util.js';
+import { recordingFileName } from '../../../util.js';
 
 const RecordingPreview = ({ deviceType, url, mimeType, onDownload, downloaded }) => {
   const { t } = useTranslation();
   const flavor = deviceType === 'desktop' ? 'presentation' : 'presenter';
-
-  // Determine the correct filename extension.
-  // TODO: we might want to parse the mime string in the future? But right now,
-  // browsers either record in webm or mp4.
-  let fileExt;
-  if (mimeType && mimeType.startsWith("video/webm")) {
-    fileExt = "webm";
-  } else if (mimeType && mimeType.startsWith("video/mp4")) {
-    fileExt = "mp4";
-  } else if (onSafari()) {
-    // Safari does not understand webm
-    fileExt = "mp4";
-  } else {
-    // If we know nothing, our best guess is webm.
-    fileExt = "webm";
-  }
-  const downloadName = `oc-studio-${now_as_string()}-${flavor}.${fileExt}`;
+  const downloadName = recordingFileName(mimeType, flavor);
 
   if (!url) {
     return null;
@@ -98,15 +82,3 @@ const RecordingPreview = ({ deviceType, url, mimeType, onDownload, downloaded })
 };
 
 export default RecordingPreview;
-
-const now_as_string = () => {
-  const pad2 = n => n >= 10 ? '' + n : '0' + n;
-
-  const now = new Date();
-  return ''
-    + now.getFullYear() + '-'
-    + pad2(now.getMonth() + 1) + '-'
-    + pad2(now.getDate()) + '_'
-    + pad2(now.getHours()) + '-'
-    + pad2(now.getMinutes());
-};

--- a/src/util.js
+++ b/src/util.js
@@ -33,8 +33,8 @@ export const isUserCaptureSupported = () =>
 // record the media streams.
 export const isRecordingSupported = () => typeof MediaRecorder !== 'undefined';
 
-// Checks if this runs in Safari.
-export const onSafari = () => /Safari/i.test(navigator.userAgent);
+// Checks if this runs in Safari. Check from https://stackoverflow.com/a/23522755/
+export const onSafari = () => /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 
 // Returns the dimensions as [w, h] array or `null` if there is no video track.
 export const dimensionsOf = stream => {

--- a/src/util.js
+++ b/src/util.js
@@ -41,3 +41,49 @@ export const dimensionsOf = stream => {
   const { width, height } = stream?.getVideoTracks()?.[0]?.getSettings() ?? {};
   return [width, height];
 };
+
+// Converts the MIME type into a file extension.
+export const mimeToExt = mime => {
+  if (mime) {
+    const lowerMime = mime.toLowerCase();
+    if (lowerMime.startsWith("video/webm")) {
+      return "webm";
+    }
+    if (lowerMime.startsWith("video/mp4")) {
+      return "mp4";
+    }
+    if (lowerMime.startsWith("video/x-matroska")) {
+      return "mkv";
+    }
+    if (lowerMime.startsWith("video/avi")) {
+      return "avi";
+    }
+    if (lowerMime.startsWith("video/quicktime")) {
+      return "mov";
+    }
+  }
+
+  // If we know nothing, our best guess is webm; except for Safari which does
+  // not understand webm: there it's mp4.
+  return onSafari() ? "mp4" : "webm";
+}
+
+// Returns a suitable filename for a recording with the MIME type `mime` and the
+// given `flavor`. The latter should be either `presenter` or `presentation`.
+// `mime` can be null or a string and is converted to a file extension on a best
+// effort basis.
+export const recordingFileName = (mime, flavor) => {
+  return `oc-studio-${nowAsString()}-${flavor}.${mimeToExt(mime)}`;
+};
+
+const nowAsString = () => {
+  const pad2 = n => n >= 10 ? '' + n : '0' + n;
+
+  const now = new Date();
+  return ''
+    + now.getFullYear() + '-'
+    + pad2(now.getMonth() + 1) + '-'
+    + pad2(now.getDate()) + '_'
+    + pad2(now.getHours()) + '-'
+    + pad2(now.getMinutes());
+};


### PR DESCRIPTION
Fixes #486 
Fixes #485 

Studio now also checks for `video/x-matroska` and sets the file extension to `.mkv` appropriately. When uploading to OC, the file extension is now also correctly chosen instead of being hardcoded as `webm`. Finally, the Safari browser detection is fixed.

@mtneug Could you check if this solves your problems? This version is deployed [here](https://test.studio.opencast.org/build-20200318132554-LukasKalbertodt-opencast-studio-000138-fix-file-extension-again/). If you can't test this today (which is not a problem of course!) it would be great if you could tell me. Thanks!