### PR TITLE
Do not show on-close warning if the recording has been up or downloaded

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,7 +7,7 @@ import { useState, Fragment } from 'react';
 import { BrowserRouter as Router, Switch, Redirect, Route, useLocation } from 'react-router-dom';
 import { Beforeunload } from 'react-beforeunload';
 
-import { Provider, useStudioState } from './studio-state';
+import { Provider, useStudioState, STATE_UPLOADED } from './studio-state';
 
 import About from './ui/about';
 import Header from './ui/header';
@@ -66,9 +66,12 @@ const Routes = ({ settingsManager, userHasWebcam }) => {
 };
 
 const PreventClose = () => {
-  const { recordings } = useStudioState();
+  const { recordings, upload } = useStudioState();
+  const downloaded = recordings.every(rec => rec.downloaded);
+  const uploaded = upload.state === STATE_UPLOADED;
+
   const handler = event => {
-    if (recordings?.length > 0) {
+    if (recordings?.length > 0 && !uploaded && !downloaded) {
       event.preventDefault();
     }
   };


### PR DESCRIPTION
This PR currently does not relax the warning of the "Start new recording button". 

@lkiesow Just merge if you're happy with this or tell me if I should still relax the other warning as well.