### PR TITLE
Add two fallbacks to make sure old recordings are not accidentally kept

### DIFF
--- a/src/studio-state.js
+++ b/src/studio-state.js
@@ -88,8 +88,20 @@ const reducer = (state, action) => {
     case 'STOP_RECORDING':
       return { ...state, isRecording: false };
 
+    case 'CLEAR_RECORDINGS':
+      return { ...state, recordings: [] };
+
     case 'ADD_RECORDING':
-      return { ...state, recordings: [...state.recordings, action.payload] };
+      // We remove all recordings with the same device type as the new one. This
+      // *should* in theory never happen as all recordings are cleared before
+      // new ones can be added. However, in rare case, this might not be true
+      // and the user ends up with strange recordings. Just to be sure, we
+      // remove old recordings here.
+      const recordings = [
+        ...state.recordings.filter(r => r.deviceType !== action.payload.deviceType),
+        action.payload,
+      ];
+      return { ...state, recordings };
 
     case 'UPLOAD_ERROR':
       return { ...state, upload: { ...state.upload, error: action.payload, state: STATE_ERROR }};

--- a/src/ui/studio/recording/recording-controls.js
+++ b/src/ui/studio/recording/recording-controls.js
@@ -63,6 +63,10 @@ export default function RecordingControls({
   });
 
   const record = () => {
+    // In theory, we should never have recordings at this point. But just to be
+    // sure, in case of a bug elsewhere, we clear the recordings here.
+    dispatch({ type: 'CLEAR_RECORDINGS' });
+
     if (displayStream) {
       const onStop = addRecordOnStop(dispatch, 'desktop');
       const stream = mixAudioIntoVideo(audioStream, displayStream);


### PR DESCRIPTION
We observed one user uploading two "presenter" (webcam) videos from
Studio a few days ago. It seemed like the user somehow managed to
record a new video without removing the old one. I checked the code and
I unfortunately can't find the bug. I don't understand how this could
happen. Maybe the user used an old version of Studio, but maybe there
are some rare cases where this can happen. To make this even less
likely, this commit adds two checks that remove old recordings at
different times if appropriate.