### PR TITLE
Fix build on OSX

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
   "scripts": {
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
-    "start": "REACT_APP_GIT_SHA=$(git rev-parse --short HEAD) REACT_APP_BUILD_DATE=$(date --utc '+%Y-%m-%d') react-scripts start",
-    "build": "REACT_APP_GIT_SHA=$(git rev-parse --short HEAD) REACT_APP_BUILD_DATE=$(date --utc '+%Y-%m-%d') react-scripts build",
+    "start": "REACT_APP_GIT_SHA=$(git rev-parse --short HEAD) REACT_APP_BUILD_DATE=$(date -u '+%Y-%m-%d') react-scripts start",
+    "build": "REACT_APP_GIT_SHA=$(git rev-parse --short HEAD) REACT_APP_BUILD_DATE=$(date -u '+%Y-%m-%d') react-scripts build",
     "lint": "eslint src/",
     "pretest": "npm run lint",
     "test": "react-scripts test",


### PR DESCRIPTION
This PR fix the build on OSX

The command  `date --utc` does not work on OSX. I replaced it by `date -u` that works on `OSX` and also on `Linux`