### PR TITLE
About Page Maximum Width

### DIFF
--- a/src/ui/about.js
+++ b/src/ui/about.js
@@ -54,7 +54,7 @@ function LegalNotices() {
 function About(props) {
   return (
     <Container>
-      <article>
+      <article sx={{ maxWidth: '900px', margin: '0 auto' }}>
         <header>
           <Styled.h1>Opencast Studio</Styled.h1>
         </header>


### PR DESCRIPTION
This patch limits the maximum width of the about page to prevent weird
looking, very wide, single line paragraphs.