### PR TITLE
Gracefully handle loss of video and audio stream

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -64,6 +64,9 @@
   "back-button-label": "Zurück",
   "next-button-label": "Weiter",
 
+  "error-lost-video-stream": "Video-Stream endete unerwartet! Wurde eine Kamera getrennt oder haben Sie versehentlich die Videofreigabe beendet?",
+  "error-lost-video-stream-end-recording": "Infolgedessen wurde die aktive Aufnahme vorzeitig beendet.",
+
   "review-heading": "Zufrieden mit der Aufnahme?",
   "review-error-empty-recording": "Fehler: Ihre Aufzeichnung ist leer. Haben Sie die Aufzeichnung unmittelbar nach dem Starten beendet? Stellen Sie auch bitte sicher, dass Ihr System leistungsstark genug ist, um Videos aufzuzeichnen (das ist möglicherweise nicht der Fall, falls andere Anwendungen Ihr System stark auslasten oder Ihr Gerät sehr alt ist). Falls Ihr System genug Leistung besitzt, Ihre Aufnahme länger als wenige Sekunden ist, und Sie trotzdem diesen Fehler sehen, melden Sie dies bitte als Bug auf GitHub.",
 

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -65,7 +65,8 @@
   "next-button-label": "Weiter",
 
   "error-lost-video-stream": "Video-Stream endete unerwartet! Wurde eine Kamera getrennt oder haben Sie versehentlich die Videofreigabe beendet?",
-  "error-lost-video-stream-end-recording": "Infolgedessen wurde die aktive Aufnahme vorzeitig beendet.",
+  "error-lost-audio-stream": "Audio-Stream endete unerwartet! Wurde ein Mikrofon getrennt oder haben Sie versehentlich die Audiofreigabe beendet?",
+  "error-lost-stream-end-recording": "Ein Video- oder Audio-Stream endete unerwartet! Infolgedessen wurde die aktive Aufnahme vorzeitig beendet. Wurde ein Mikrofon oder eine Kamera getrennt? Oder haben Sie versehentlich die Medienfreigabe beendet oder Studio die notwendigen Berechtigungen entzogen?",
 
   "review-heading": "Zufrieden mit der Aufnahme?",
   "review-error-empty-recording": "Fehler: Ihre Aufzeichnung ist leer. Haben Sie die Aufzeichnung unmittelbar nach dem Starten beendet? Stellen Sie auch bitte sicher, dass Ihr System leistungsstark genug ist, um Videos aufzuzeichnen (das ist möglicherweise nicht der Fall, falls andere Anwendungen Ihr System stark auslasten oder Ihr Gerät sehr alt ist). Falls Ihr System genug Leistung besitzt, Ihre Aufnahme länger als wenige Sekunden ist, und Sie trotzdem diesen Fehler sehen, melden Sie dies bitte als Bug auf GitHub.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -66,6 +66,8 @@
   "sources-display": "Display",
   "sources-user": "Camera",
 
+  "error-lost-video-stream": "Video stream unexpectedly ended! Did a camera disconnect or did you accidentally unshare a video source?",
+  "error-lost-video-stream-end-recording": "Consequently, the active recording was prematurely stopped!",
 
   "review-heading": "Happy with your recording?",
   "review-error-empty-recording": "Error: your recording is completely empty. Did you stop the recording almost immediately after starting it? Additionally, please make sure that your system is powerful enough to record a video stream (this might not be the case if another application heavily utilizes your system or if your device is very old). If your system is powerful enough to record, you recorded for more than a few seconds, and you are still seeing this error: please report this as a bug on GitHub.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -67,7 +67,8 @@
   "sources-user": "Camera",
 
   "error-lost-video-stream": "Video stream unexpectedly ended! Did a camera disconnect or did you accidentally unshare a video source?",
-  "error-lost-video-stream-end-recording": "Consequently, the active recording was prematurely stopped!",
+  "error-lost-audio-stream": "Audio stream unexpectedly ended! Did the microphone disconnect or did you accidentally unshare the audio source?",
+  "error-lost-stream-end-recording": "A video or audio stream unexpectedly ended and thus, the active recording was prematurely stopped! Did a microphone or a camera disconnect? Or did you accidentally unshare the media source or revoke the necessary permissions?",
 
   "review-heading": "Happy with your recording?",
   "review-error-empty-recording": "Error: your recording is completely empty. Did you stop the recording almost immediately after starting it? Additionally, please make sure that your system is powerful enough to record a video stream (this might not be the case if another application heavily utilizes your system or if your device is very old). If your system is powerful enough to record, you recorded for more than a few seconds, and you are still seeing this error: please report this as a bug on GitHub.",

--- a/src/recorder.js
+++ b/src/recorder.js
@@ -41,7 +41,11 @@ export default class Recorder {
       const mimeType = _recData[0]?.type || this.recorder.mimeType;
       const media = new Blob(_recData, { type: mimeType });
       const url = URL.createObjectURL(media);
+
+      // Reset this state.
       this.recorder = null;
+      this.isRecording = false;
+
       options.onStop && options.onStop({ url, media, mimeType, dimensions });
     };
 
@@ -71,7 +75,8 @@ export default class Recorder {
   }
 
   stop() {
-    this.recorder.stop();
-    this.isRecording = false;
+    if (this.isRecording) {
+      this.recorder.stop();
+    }
   }
 }

--- a/src/studio-state.js
+++ b/src/studio-state.js
@@ -116,7 +116,7 @@ const reducer = (state, action) => {
       return { ...state, isRecording: false, prematureRecordingEnd: true };
 
     case 'CLEAR_RECORDINGS':
-      return { ...state, recordings: [] };
+      return { ...state, recordings: [], prematureRecordingEnd: false };
 
     case 'ADD_RECORDING':
       // We remove all recordings with the same device type as the new one. This

--- a/src/studio-state.js
+++ b/src/studio-state.js
@@ -10,6 +10,11 @@ export const MICROPHONE_REQUEST = 'microphone_request';
 export const NO_AUDIO = 'no-audio';
 export const NONE = 'none';
 
+export const VIDEO_SOURCE_BOTH = 'both';
+export const VIDEO_SOURCE_DISPLAY = 'display';
+export const VIDEO_SOURCE_USER = 'user';
+export const VIDEO_SOURCE_NONE = 'none';
+
 export const STATE_NOT_UPLOADED = 'not_uploaded';
 export const STATE_UPLOADING = 'uploading';
 export const STATE_UPLOADED = 'uploaded';
@@ -41,6 +46,7 @@ const initialState = () => ({
   userUnexpectedEnd: false,
   userSupported: isUserCaptureSupported(),
 
+  videoChoice: VIDEO_SOURCE_NONE,
   audioChoice: NONE,
 
   isRecording: false,
@@ -59,6 +65,9 @@ const reducer = (state, action) => {
   switch (action.type) {
     case 'CHOOSE_AUDIO':
       return { ...state, audioChoice: action.payload };
+
+    case 'CHOOSE_VIDEO':
+      return { ...state, videoChoice: action.payload };
 
     case 'SHARE_AUDIO':
       return {

--- a/src/studio-state.js
+++ b/src/studio-state.js
@@ -32,16 +32,18 @@ const initialState = () => ({
 
   displayAllowed: null,
   displayStream: null,
+  displayUnexpectedEnd: false,
   displaySupported: isDisplayCaptureSupported(),
 
   userAllowed: null,
   userStream: null,
+  userUnexpectedEnd: false,
   userSupported: isUserCaptureSupported(),
 
   audioChoice: NONE,
 
   isRecording: false,
-
+  prematureRecordingEnd: false,
   recordings: [],
 
   upload: {
@@ -67,28 +69,42 @@ const reducer = (state, action) => {
       return { ...state, audioStream: null };
 
     case 'SHARE_DISPLAY':
-      return { ...state, displayStream: action.payload, displayAllowed: true };
+      return {
+        ...state,
+        displayStream: action.payload,
+        displayAllowed: true,
+        displayUnexpectedEnd: false,
+      };
 
     case 'BLOCK_DISPLAY':
-      return { ...state, displayStream: null, displayAllowed: false };
+      return { ...state, displayStream: null, displayAllowed: false, displayUnexpectedEnd: false };
 
     case 'UNSHARE_DISPLAY':
-      return { ...state, displayStream: null };
+      return { ...state, displayStream: null, displayUnexpectedEnd: false };
+
+    case 'DISPLAY_UNEXPETED_END':
+      return { ...state, displayStream: null, displayUnexpectedEnd: true };
 
     case 'SHARE_USER':
-      return { ...state, userStream: action.payload, userAllowed: true };
+      return { ...state, userStream: action.payload, userAllowed: true, userUnexpectedEnd: false };
 
     case 'BLOCK_USER':
-      return { ...state, userStream: null, userAllowed: false };
+      return { ...state, userStream: null, userAllowed: false, userUnexpectedEnd: false };
 
     case 'UNSHARE_USER':
-      return { ...state, userStream: null };
+      return { ...state, userStream: null, userUnexpectedEnd: false };
+
+    case 'USER_UNEXPETED_END':
+      return { ...state, userStream: null, userUnexpectedEnd: true };
 
     case 'START_RECORDING':
       return { ...state, isRecording: true };
 
     case 'STOP_RECORDING':
       return { ...state, isRecording: false };
+
+    case 'STOP_RECORDING_PREMATURELY':
+      return { ...state, isRecording: false, prematureRecordingEnd: true };
 
     case 'CLEAR_RECORDINGS':
       return { ...state, recordings: [] };

--- a/src/studio-state.js
+++ b/src/studio-state.js
@@ -28,6 +28,7 @@ export let metaData = { ...defaultMetaData };
 const initialState = () => ({
   audioAllowed: null,
   audioStream: null,
+  audioUnexpectedEnd: false,
   audioSupported: isUserCaptureSupported(),
 
   displayAllowed: null,
@@ -60,13 +61,21 @@ const reducer = (state, action) => {
       return { ...state, audioChoice: action.payload };
 
     case 'SHARE_AUDIO':
-      return { ...state, audioStream: action.payload, audioAllowed: true };
+      return {
+        ...state,
+        audioStream: action.payload,
+        audioAllowed: true,
+        audioUnexpectedEnd: false,
+      };
 
     case 'BLOCK_AUDIO':
-      return { ...state, audioStream: null, audioAllowed: false };
+      return { ...state, audioStream: null, audioAllowed: false, audioUnexpectedEnd: false };
 
     case 'UNSHARE_AUDIO':
-      return { ...state, audioStream: null };
+      return { ...state, audioStream: null, audioUnexpectedEnd: false };
+
+    case 'AUDIO_UNEXPETED_END':
+      return { ...state, audioStream: null, audioUnexpectedEnd: true };
 
     case 'SHARE_DISPLAY':
       return {

--- a/src/ui/studio/audio-setup/index.js
+++ b/src/ui/studio/audio-setup/index.js
@@ -26,8 +26,7 @@ export default function AudioSetup(props) {
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const state = useStudioState();
-  const audioStream = state.audioStream;
-  const audioAllowed = state.audioAllowed;
+  const { audioStream, audioAllowed, audioUnexpectedEnd } = state;
 
   const nextIsDisabled = state.audioChoice === NONE
     || state.audioChoice === MICROPHONE_REQUEST
@@ -79,7 +78,7 @@ export default function AudioSetup(props) {
         <OptionButton
           icon={faMicrophone}
           label={t('sources-audio-microphone')}
-          selected={state.audioChoice === MICROPHONE}
+          selected={state.audioChoice === MICROPHONE && !audioUnexpectedEnd}
           onClick={selectMicrophone}
         >
           { state.audioChoice === MICROPHONE_REQUEST && <Spinner size="75"/> }
@@ -90,6 +89,11 @@ export default function AudioSetup(props) {
                 {t('source-audio-not-allowed-title')}
               </Heading>
               <Text variant='text'>{t('source-audio-not-allowed-text')}</Text>
+            </Notification>
+          )}
+          { audioUnexpectedEnd && (
+            <Notification isDanger sx={{ mt: 2 }}>
+              <Text variant='text'>{t('error-lost-audio-stream')}</Text>
             </Notification>
           )}
         </OptionButton>

--- a/src/ui/studio/capturer.js
+++ b/src/ui/studio/capturer.js
@@ -42,7 +42,7 @@ export async function startDisplayCapture(dispatch, settings) {
     const stream = await navigator.mediaDevices.getDisplayMedia(constraints);
     stream.getTracks().forEach(track => {
       track.onended = () => {
-        dispatch({ type: 'UNSHARE_DISPLAY' });
+        dispatch({ type: 'DISPLAY_UNEXPETED_END' });
       };
     });
 
@@ -76,7 +76,7 @@ export async function startUserCapture(dispatch, settings) {
     const stream = await navigator.mediaDevices.getUserMedia(constraints);
     stream.getTracks().forEach(track => {
       track.onended = () => {
-        dispatch({ type: 'UNSHARE_USER' });
+        dispatch({ type: 'USER_UNEXPETED_END' });
       };
     });
     dispatch({ type: 'SHARE_USER', payload: stream });

--- a/src/ui/studio/capturer.js
+++ b/src/ui/studio/capturer.js
@@ -6,7 +6,7 @@ export async function startAudioCapture(dispatch, deviceId = null) {
     });
     stream.getTracks().forEach(track => {
       track.onended = () => {
-        dispatch({ type: 'UNSHARE_AUDIO' });
+        dispatch({ type: 'AUDIO_UNEXPETED_END' });
       };
     });
 

--- a/src/ui/studio/recording/index.js
+++ b/src/ui/studio/recording/index.js
@@ -52,6 +52,11 @@ export default function Recording(props) {
           <Text>{t('error-lost-video-stream')}</Text>
         </Notification>
       )}
+      { state.audioUnexpectedEnd && (
+        <Notification isDanger>
+          <Text>{t('error-lost-audio-stream')}</Text>
+        </Notification>
+      )}
 
       <MediaDevices recordingState={recordingState} />
 

--- a/src/ui/studio/recording/index.js
+++ b/src/ui/studio/recording/index.js
@@ -2,8 +2,9 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui';
 
-import { Flex } from '@theme-ui/components';
-import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Flex, Text } from '@theme-ui/components';
+import { useCallback, useState } from 'react';
 
 import { useStudioState, useDispatch } from '../../../studio-state';
 import { useOpencast } from '../../../opencast';
@@ -13,6 +14,7 @@ import { ActionButtons } from '../elements';
 import MediaDevices from './media-devices';
 import RecordingControls from './recording-controls';
 import { stopCapture } from '../capturer';
+import Notification from '../../notification';
 
 
 export const STATE_INACTIVE = 'inactive';
@@ -21,17 +23,12 @@ export const STATE_RECORDING = 'recording';
 
 
 export default function Recording(props) {
+  const { t } = useTranslation();
   const state = useStudioState();
   const recordingDispatch = useDispatch();
   const opencast = useOpencast();
 
   const [recordingState, setRecordingState] = useState(STATE_INACTIVE);
-  useEffect(() => {
-    if (!(state.displayStream || state.userStream)) {
-      props.firstStep();
-    }
-  }, [props, state.displayStream, state.userStream]);
-
 
   const handleRecorded = () => {
     opencast.refreshConnection();
@@ -50,6 +47,12 @@ export default function Recording(props) {
       position: 'relative',
       flexGrow: 1,
     }}>
+      { (state.displayUnexpectedEnd || state.userUnexpectedEnd) && (
+        <Notification isDanger>
+          <Text>{t('error-lost-video-stream')}</Text>
+        </Notification>
+      )}
+
       <MediaDevices recordingState={recordingState} />
 
       <div sx={{ m: 3 }}>

--- a/src/ui/studio/recording/media-devices.js
+++ b/src/ui/studio/recording/media-devices.js
@@ -4,7 +4,7 @@ import { jsx } from 'theme-ui';
 
 import { useTranslation } from 'react-i18next';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPause } from '@fortawesome/free-solid-svg-icons';
+import { faExclamationTriangle, faPause } from '@fortawesome/free-solid-svg-icons';
 import { useEffect, useRef } from 'react';
 
 import { STATE_PAUSED } from './index.js';
@@ -14,18 +14,18 @@ import { dimensionsOf } from '../../../util.js';
 
 export default function MediaDevices({ recordingState }) {
   const { t } = useTranslation();
-  const { displayStream, userStream } = useStudioState();
+  const { displayStream, userStream, displayUnexpectedEnd, userUnexpectedEnd } = useStudioState();
 
   const paused = recordingState === STATE_PAUSED;
 
   let children = [];
-  if (displayStream) {
+  if (displayStream || displayUnexpectedEnd) {
     children.push({
       body: <MediaDevice title={t('share-desktop')} stream={displayStream} paused={paused} />,
       dimensions: () => dimensionsOf(displayStream),
     });
   }
-  if (userStream) {
+  if (userStream || userUnexpectedEnd) {
     children.push({
       body: <MediaDevice title={t('share-camera')} stream={userStream} paused={paused} />,
       dimensions: () => dimensionsOf(userStream),
@@ -41,7 +41,7 @@ function MediaDevice({ title, stream, paused }) {
 
   useEffect(() => {
     const v = videoRef.current;
-    if (v && typeof stream != 'undefined') {
+    if (v && stream) {
       if (!v.srcObject) {
         v.srcObject = stream;
       }
@@ -52,10 +52,24 @@ function MediaDevice({ title, stream, paused }) {
       } else {
         v.play();
       }
-    }
 
-    return () => v.removeEventListener('resize', resizeVideoBox);
+      return () => v.removeEventListener('resize', resizeVideoBox);
+    }
   });
+
+  if (!stream) {
+    return (
+      <div sx={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}>
+        <FontAwesomeIcon icon={faExclamationTriangle} size="3x" />
+      </div>
+    );
+  }
 
   return (
     <div

--- a/src/ui/studio/recording/recording-controls.js
+++ b/src/ui/studio/recording/recording-controls.js
@@ -100,6 +100,8 @@ export default function RecordingControls({
   };
 
   useEffect(() => {
+    // Detect if a stream ended unexpectedly. In that was we want to stop the
+    // recording completely.
     const unexpectedEnd = userUnexpectedEnd || displayUnexpectedEnd || audioUnexpectedEnd;
     if (unexpectedEnd && recordingState === STATE_RECORDING) {
       stop(true);

--- a/src/ui/studio/recording/recording-controls.js
+++ b/src/ui/studio/recording/recording-controls.js
@@ -45,13 +45,15 @@ export default function RecordingControls({
     userStream,
     userUnexpectedEnd,
     displayUnexpectedEnd,
+    audioUnexpectedEnd,
   } = useStudioState();
 
 
   const desktopRecorder = useRef(null);
   const videoRecorder = useRef(null);
 
-  const canRecord = (displayStream || userStream) && !userUnexpectedEnd && ! displayUnexpectedEnd;
+  const canRecord = (displayStream || userStream)
+    && !userUnexpectedEnd && !displayUnexpectedEnd && !audioUnexpectedEnd;
 
   const history = useHistory();
 
@@ -98,7 +100,8 @@ export default function RecordingControls({
   };
 
   useEffect(() => {
-    if ((userUnexpectedEnd || displayUnexpectedEnd) && recordingState === STATE_RECORDING) {
+    const unexpectedEnd = userUnexpectedEnd || displayUnexpectedEnd || audioUnexpectedEnd;
+    if (unexpectedEnd && recordingState === STATE_RECORDING) {
       stop(true);
     }
 

--- a/src/ui/studio/recording/recording-controls.js
+++ b/src/ui/studio/recording/recording-controls.js
@@ -39,28 +39,21 @@ export default function RecordingControls({
   const dispatch = useDispatch();
   const settings = useSettings();
 
-  const { audioStream, displayStream, userStream } = useStudioState();
+  const {
+    audioStream,
+    displayStream,
+    userStream,
+    userUnexpectedEnd,
+    displayUnexpectedEnd,
+  } = useStudioState();
+
 
   const desktopRecorder = useRef(null);
   const videoRecorder = useRef(null);
 
-  const hasStreams = displayStream || userStream;
+  const canRecord = (displayStream || userStream) && !userUnexpectedEnd && ! displayUnexpectedEnd;
 
   const history = useHistory();
-
-  // reset after mounting
-  useEffect(() => {
-    history.listen(() => {
-      // This only happens when the user uses "back" or "forward" in their
-      // browser and they confirm they want to discard the recording.
-      if (recordingState !== 'STATE_INACTIVE') {
-        dispatch({ type: 'STOP_RECORDING' });
-      }
-
-      unblockers.forEach(b => b());
-      unblockers = [];
-    });
-  });
 
   const record = () => {
     // In theory, we should never have recordings at this point. But just to be
@@ -95,14 +88,32 @@ export default function RecordingControls({
     videoRecorder.current && videoRecorder.current.pause();
   };
 
-  const stop = () => {
+  const stop = (premature = false) => {
     desktopRecorder.current && desktopRecorder.current.stop();
     videoRecorder.current && videoRecorder.current.stop();
     handleRecorded();
-    dispatch({ type: 'STOP_RECORDING' });
+    dispatch({ type: premature ? 'STOP_RECORDING_PREMATURELY' : 'STOP_RECORDING' });
     unblockers.forEach(b => b());
     unblockers = [];
   };
+
+  useEffect(() => {
+    if ((userUnexpectedEnd || displayUnexpectedEnd) && recordingState === STATE_RECORDING) {
+      stop(true);
+    }
+
+    history.listen(() => {
+      // This only happens when the user uses "back" or "forward" in their
+      // browser and they confirm they want to discard the recording.
+      if (recordingState !== 'STATE_INACTIVE') {
+        dispatch({ type: 'STOP_RECORDING' });
+      }
+
+      unblockers.forEach(b => b());
+      unblockers = [];
+    });
+  });
+
 
   const handlePause = () => {
     setRecordingState(STATE_PAUSED);
@@ -115,7 +126,7 @@ export default function RecordingControls({
   };
 
   const handleRecord = () => {
-    if (!hasStreams) {
+    if (!canRecord) {
       return;
     }
     setRecordingState(STATE_RECORDING);
@@ -159,7 +170,7 @@ export default function RecordingControls({
               title={t('record-button-title')}
               recordingState={recordingState}
               onClick={handleRecord}
-              disabled={!hasStreams}
+              disabled={!canRecord}
             />
           ) : (
             <StopButton

--- a/src/ui/studio/review/index.js
+++ b/src/ui/studio/review/index.js
@@ -44,9 +44,7 @@ export default function Review(props) {
 
       { prematureRecordingEnd && (
         <Notification isDanger>
-          <Text>
-            {t('error-lost-video-stream')} {t('error-lost-video-stream-end-recording')}
-          </Text>
+          <Text>{t('error-lost-stream-end-recording')}</Text>
         </Notification>
       )}
 

--- a/src/ui/studio/review/index.js
+++ b/src/ui/studio/review/index.js
@@ -3,7 +3,7 @@
 import { jsx, Styled } from 'theme-ui';
 
 import React, { useEffect } from 'react';
-import { Flex, Spinner } from '@theme-ui/components';
+import { Flex, Spinner, Text } from '@theme-ui/components';
 import { useTranslation } from 'react-i18next';
 
 import { ActionButtons, VideoBox } from '../elements';
@@ -14,7 +14,7 @@ import Notification from '../../notification';
 export default function Review(props) {
   const { t } = useTranslation();
   const recordingDispatch = useDispatch();
-  const { recordings } = useStudioState();
+  const { recordings, prematureRecordingEnd } = useStudioState();
   const emptyRecording = recordings.some(rec => rec.media.size === 0);
 
   const handleBack = () => {
@@ -41,6 +41,14 @@ export default function Review(props) {
       <Styled.h1 sx={{ textAlign: 'center', fontSize: ['26px', '30px', '32px'] }}>
         {t('review-heading')}
       </Styled.h1>
+
+      { prematureRecordingEnd && (
+        <Notification isDanger>
+          <Text>
+            {t('error-lost-video-stream')} {t('error-lost-video-stream-end-recording')}
+          </Text>
+        </Notification>
+      )}
 
       { emptyRecording && (
         <Notification isDanger>{t('review-error-empty-recording')}</Notification>

--- a/src/ui/studio/video-setup/index.js
+++ b/src/ui/studio/video-setup/index.js
@@ -91,6 +91,11 @@ export default function VideoSetup(props) {
       <Text>{t('source-display-not-allowed-text')}</Text>
     </Notification>
   );
+  const unexpectedEndWarning = (state.userUnexpectedEnd || state.displayUnexpectedEnd) && (
+    <Notification key="unexpexted-stream-end-warning" isDanger>
+      <Text>{t('error-lost-video-stream')}</Text>
+    </Notification>
+  );
 
   // The body depends on which source is currently selected.
   let hideActionButtons;
@@ -149,10 +154,13 @@ export default function VideoSetup(props) {
       hideActionButtons = !state.userStream && state.userAllowed !== false;
       body = <SourcePreview
         reselectSource={reselectSource}
-        warnings={userWarning}
-        inputs={[
-          { kind: t('sources-user'), stream: state.userStream, allowed: state.userAllowed }
-        ]}
+        warnings={[userWarning, unexpectedEndWarning]}
+        inputs={[{
+          kind: t('sources-user'),
+          stream: state.userStream,
+          allowed: state.userAllowed,
+          unexpectedEnd: state.userUnexpectedEnd,
+        }]}
       />;
       break;
 
@@ -161,11 +169,12 @@ export default function VideoSetup(props) {
       hideActionButtons = !state.displayStream && state.displayAllowed !== false;
       body = <SourcePreview
         reselectSource={reselectSource}
-        warnings={displayWarning}
+        warnings={[displayWarning, unexpectedEndWarning]}
         inputs={[{
           kind: t('sources-display'),
           stream: state.displayStream,
           allowed: state.displayAllowed,
+          unexpectedEnd: state.displayUnexpectedEnd,
         }]}
       />;
       break;
@@ -176,14 +185,20 @@ export default function VideoSetup(props) {
         || (!state.displayStream && state.displayAllowed !== false);
       body = <SourcePreview
         reselectSource={reselectSource}
-        warnings={[displayWarning, userWarning]}
+        warnings={[displayWarning, userWarning, unexpectedEndWarning]}
         inputs={[
           {
             kind: t('sources-display'),
             stream: state.displayStream,
             allowed: state.displayAllowed,
+            unexpectedEnd: state.displayUnexpectedEnd,
           },
-          { kind: t('sources-user'), stream: state.userStream, allowed: state.userAllowed },
+          {
+            kind: t('sources-user'),
+            stream: state.userStream,
+            allowed: state.userAllowed,
+            unexpectedEnd: state.userUnexpectedEnd,
+          },
         ]}
       />;
       break;

--- a/src/ui/studio/video-setup/index.js
+++ b/src/ui/studio/video-setup/index.js
@@ -209,6 +209,8 @@ export default function VideoSetup(props) {
       return <p>Something went very wrong</p>;
   };
 
+  const hideReselectSource = hideActionButtons
+    && !state.userUnexpectedEnd && !state.displayUnexpectedEnd;
 
   return (
     <Container
@@ -228,8 +230,11 @@ export default function VideoSetup(props) {
       { activeSource !== VIDEO_SOURCE_NONE && <div sx={{ mb: 3 }} /> }
 
       { activeSource !== VIDEO_SOURCE_NONE && <ActionButtons
-        next={hideActionButtons ? null : { onClick: () => props.nextStep(), disabled: nextDisabled }}
-        prev={hideActionButtons ? null : {
+        next={hideActionButtons ? null : {
+          onClick: () => props.nextStep(),
+          disabled: nextDisabled,
+        }}
+        prev={hideReselectSource ? null : {
           onClick: reselectSource,
           disabled: false,
           label: 'sources-video-reselect-source',

--- a/src/ui/studio/video-setup/preview.js
+++ b/src/ui/studio/video-setup/preview.js
@@ -56,7 +56,7 @@ function StreamPreview({ input, text }) {
 
   return (
     <Card sx={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
-      <PreviewVideo allowed={input.allowed} stream={stream} />
+      <PreviewVideo allowed={input.allowed} unexpectedEnd={input.unexpectedEnd} stream={stream} />
       <Text p={2} color="muted" sx={{ height: `${SUBBOX_HEIGHT}px` }}>
         {text}
         {track && `: ${width}×${height}`}
@@ -65,7 +65,7 @@ function StreamPreview({ input, text }) {
   );
 }
 
-export const PreviewVideo = ({ allowed, stream, ...props }) => {
+export const PreviewVideo = ({ allowed, stream, unexpectedEnd, ...props }) => {
   const resizeVideoBox = useVideoBoxResize();
 
   const videoRef = useRef();
@@ -87,7 +87,7 @@ export const PreviewVideo = ({ allowed, stream, ...props }) => {
 
   if (!stream) {
     let inner;
-    if (allowed === false) {
+    if (allowed === false || unexpectedEnd) {
       inner = <FontAwesomeIcon icon={faExclamationTriangle} size="3x" />;
     } else {
       inner = <Spinner size="75"/>;


### PR DESCRIPTION
Fixes #575 

The second commit I couldn't properly test as I couldn't figure out how to only end the audio stream without ending a video stream as well. But it should work :P

Loss of stream can happen in fairly many situations. #575 mentions closing the captured window, but Chrome also offers a "stop sharing" overlay. You can always manually revoke media permissions in the browser. And finally, physical devices can be disconnected.