### PR TITLE
Fix rare bug in progress estimation

### DIFF
--- a/src/ui/studio/save-creation/index.js
+++ b/src/ui/studio/save-creation/index.js
@@ -104,7 +104,7 @@ export default function SaveCreation(props) {
       }
 
       const lastProgress = progressHistory[progressHistory.length - 1];
-      const timeSinceLastUpdate = Date.now() - lastProgress.timestamp;
+      const timeSinceLastUpdate = Date.now() - (lastProgress?.timestamp || 0);
       if (timeSinceLastUpdate > 3000) {
         onProgress(lastProgress.progress)
       }


### PR DESCRIPTION
If the "update regularly" interal is called before the first actual
datapoint is collected, it leads to an error currently.

Found via Sentry ([click](https://sentry.virtuos.uos.de/virtuos/opencast-studio/issues/335/)).