### PR TITLE
Configurable Studio Title

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -25,6 +25,18 @@ The following settings are currently understood by Studio. The column "shown to 
   </thead>
   <tbody>
     <tr>
+      <td><b><code>studiotitle</code></b></td>
+      <td>string</td>
+      <td><code>ASQ: Aberglaube bei Tauben - SS 2020</code></td>
+      <td>✔</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td colspan="3">
+        Set a title. This is useful if configured for a course, for instance, using <code>upload.seriesId</code> and helps the user distinguish multiple Opencast Studio tabs.
+      </td>
+    </tr>
+    <tr>
       <td><b><code>opencast.serverUrl</code></b></td>
       <td>string</td>
       <td><code>https://develop.opencast.org</code></td>

--- a/public/index.html
+++ b/public/index.html
@@ -71,6 +71,11 @@
               l.hash
             );
           }
+          if (q.studiotitle) {
+            const cleanStudioTitle = decodeURIComponent(
+                q.studiotitle.replace(/\+/g, '%20'));
+            document.title = cleanStudioTitle + ' • ' + document.title;
+          }
         }
       }(window.location))
     </script>

--- a/src/settings.js
+++ b/src/settings.js
@@ -508,6 +508,7 @@ const positiveInteger = name => ({
 
 // Defines all potential settings and their types
 const SCHEMA = {
+  studiotitle: 'string',
   opencast: {
     serverUrl: {
       _type: 'string',

--- a/src/ui/header.js
+++ b/src/ui/header.js
@@ -15,7 +15,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 
 import { useStudioState } from '../studio-state';
-
+import { useSettings } from '../settings';
 
 // The header, including a logo on the left and the navigation on the right.
 export default function Header() {
@@ -57,6 +57,7 @@ export default function Header() {
 
       {/* Actual content */}
       <Brand />
+      <Course />
       <Navigation />
     </header>
   );
@@ -79,6 +80,22 @@ const Brand = () => {
         />
       </picture>
     </Link>
+  );
+}
+
+const Course = () => {
+  const settings = useSettings();
+
+  return (
+    <Fragment>
+      <div sx={{
+        overflow: 'hidden',
+        whiteSpace: 'nowrap',
+        textOverflow: 'ellipsis',
+      }}>
+        {settings.studiotitle}
+      </div>
+    </Fragment>
   );
 }
 


### PR DESCRIPTION
Allows configuring Opencast Studio's title using the `studiotitle` configuration/setting.
This is useful if Studio is configured for a course, for instance, using `upload.seriesId` and helps the user distinguish multiple Opencast Studio tabs.
![Screenshot from 2020-04-30 20-20-51](https://user-images.githubusercontent.com/2311611/80745171-2be71400-8b20-11ea-8b8c-5eb086ade153.png)

narrow width:
![Screenshot from 2020-04-30 20-23-25](https://user-images.githubusercontent.com/2311611/80745364-7b2d4480-8b20-11ea-9ab2-3a41ac5c9199.png)
