### PR TITLE
Tweak conditions for "New recording" button and close-prevention

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,7 +7,7 @@ import { useState, Fragment } from 'react';
 import { BrowserRouter as Router, Switch, Redirect, Route, useLocation } from 'react-router-dom';
 import { Beforeunload } from 'react-beforeunload';
 
-import { Provider, useStudioState, STATE_UPLOADED } from './studio-state';
+import { Provider, useStudioState, STATE_UPLOADED, STATE_UPLOADING } from './studio-state';
 
 import About from './ui/about';
 import Header from './ui/header';
@@ -69,9 +69,10 @@ const PreventClose = () => {
   const { recordings, upload } = useStudioState();
   const downloaded = recordings.every(rec => rec.downloaded);
   const uploaded = upload.state === STATE_UPLOADED;
+  const uploading = upload.state === STATE_UPLOADING;
 
   const handler = event => {
-    if (recordings?.length > 0 && !uploaded && !downloaded) {
+    if ((recordings?.length > 0 && !uploaded && !downloaded) || uploading) {
       event.preventDefault();
     }
   };

--- a/src/ui/studio/save-creation/index.js
+++ b/src/ui/studio/save-creation/index.js
@@ -156,7 +156,9 @@ export default function SaveCreation(props) {
   };
 
   const allDownloaded = recordings.every(rec => rec.downloaded);
-  const possiblyDone = uploadState.state === STATE_UPLOADED || allDownloaded;
+  const possiblyDone = (uploadState.state === STATE_UPLOADED || allDownloaded)
+    && uploadState.state !== STATE_UPLOADING;
+  const hideBack = uploadState.state !== STATE_NOT_UPLOADED || allDownloaded;
 
   // Depending on the state, show a different thing in the upload box.
   const uploadBox = (() => {
@@ -217,7 +219,7 @@ export default function SaveCreation(props) {
 
       <ActionButtons
         next={null}
-        prev={possiblyDone ? null : {
+        prev={hideBack ? null : {
           onClick: handleBack,
           disabled: false,
         }}


### PR DESCRIPTION
In particular: if it is currently uploading, prevent leaving and do not show "New recording" button.

Fixes #596