### PR TITLE
Obtain LTI course ID from LTI session and not from user roles

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -247,7 +247,7 @@ The ACL XML template is a Mustache template. The following variables are passed 
 - `userName`: the username of the currnet user (e.g. `admin`)
 - `userRole`: the user role of the current user (e.g. `ROLE_USER_ADMIN`)
 - `roleOAuthUser`: `"ROLE_OAUTH_USER"` if this role is in `user.roles` or `undefined` otherwise
-- `ltiCourseId`: the LTI course ID extracted from user roles that end with `_Learner` or `_Instructor`. `undefined` if no such roles are within `user.roles`.
+- `ltiCourseId`: the `context_id` taken from the `/lti` endpoint or `undefined` if the field does not exist.
 - `defaultReadRoles`: a convenience array of roles that usually have read access. Always contains `userRole`. If `ltiCourseId` is defined, also contains `"${ltiCourseId}_Learner"` and `"${ltiCourseId}_Instructor"`.
 - `defaultWriteRoles`: a convenience array of roles that usually have read access. Always contains `userRole`. If `ltiCourseId` is defined, also contains `"${ltiCourseId}_Instructor"`.
 

--- a/src/opencast.js
+++ b/src/opencast.js
@@ -532,14 +532,7 @@ export class Opencast {
     }
 
     // Prepare template "view": the values that can be used within the template.
-    let ltiCourseId = this.#currentUser.roles
-      .find(r => r.endsWith('_Learner') || r.endsWith('_Instructor'))
-      ?.replace('_Learner', '')
-      .replace('_Instructor', '');
-    if (ltiCourseId === 'LTI') {
-      ltiCourseId = undefined;
-    }
-
+    const ltiCourseId = this.#ltiSession?.context_id;
     const roleOAuthUser = this.#currentUser.roles.find(r => r === 'ROLE_OAUTH_USER');
 
     let defaultReadRoles = [this.#currentUser.userRole];


### PR DESCRIPTION
Closes #511 

The previous implementation was an ugly hack. We think that this should not break anything, only fix things.

CC @lkiesow @mtneug https://github.com/elan-ev/opencast-studio/issues/567