### PR TITLE
Bring audio selection closer to video selection (UI wise) and add audio device selector

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -66,11 +66,14 @@
   "source-user-not-allowed-title": "Zugriff auf Kamera nicht möglich",
   "source-user-not-allowed-text": "Versuchen Sie, die Quelle neu auszuwählen. Falls das nicht funktioniert, laden Sie entweder diese Seite neu oder erlauben Sie dieser Seite manuell Zugriff auf Ihre Kamera (typischerweise über einen Button neben der Adressleiste Ihres Browsers). Versuchen Sie auch, andere Anwendungen, die diese Kamera nutzen, zu schließen: auf einigen Systemen können Kameras nicht von mehreren Anwendungen gleichzeitig benutzt werden.",
   "source-audio-not-allowed-title": "Zugriff auf Mikrofon nicht möglich.",
-  "source-audio-not-allowed-text": "Versuchen Sie 'Ohne Audio' und danach wieder 'Mikrofon' auszuwählen. Falls das nicht funktioniert, laden Sie entweder diese Seite neu oder erlauben Sie dieser Seite manuell Zugriff auf Ihr Mikrofon (typischerweise über einen Button neben der Adressleiste Ihres Browsers)",
+  "source-audio-not-allowed-text": "Versuchen Sie 'Audio neu auswählen' und danach wieder 'Mikrofon' auszuwählen. Falls das nicht funktioniert, laden Sie entweder diese Seite neu oder erlauben Sie dieser Seite manuell Zugriff auf Ihr Mikrofon (typischerweise über einen Button neben der Adressleiste Ihres Browsers)",
 
   "sources-audio-question": "Audio aufnehmen?",
   "sources-audio-microphone": "Mikrofon",
+  "sources-audio-microphone-selected": "Mikrofon ausgewählt",
   "sources-audio-without-audio": "Ohne Audio",
+  "sources-audio-reselect-audio": "Audio neu auswählen",
+  "sources-audio-device": "Gerät",
 
   "share-desktop": "Bildschirm teilen",
   "share-camera": "Kamera teilen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -67,7 +67,10 @@
 
   "sources-audio-question": "Record Audio?",
   "sources-audio-microphone": "Microphone",
+  "sources-audio-microphone-selected": "Microphone selected",
   "sources-audio-without-audio": "Without audio",
+  "sources-audio-reselect-audio": "Reselect audio",
+  "sources-audio-device": "Device",
 
   "sources-scenario-display-and-user": "Display & camera",
   "sources-scenario-display": "Display",
@@ -79,7 +82,7 @@
   "source-user-not-allowed-title": "Cannot access your camera",
   "source-user-not-allowed-text": "Try reselecting the source. If that does not work, either reload this page or manually allow us to access your camera (usually via a button next to your browser's address bar). If that does not help, try closing other applications that might use that camera: with some operating systems, only a single application can have access to the camera.",
   "source-audio-not-allowed-title": "Cannot access your microphone.",
-  "source-audio-not-allowed-text": "Try selecting 'No Audio' and then reselecting 'Microphone'. If that does not work, either reload this page or manually allow us to access your microphone (usually via a button next to your browser's address bar).",
+  "source-audio-not-allowed-text": "Try selecting 'Reselect audio' and then selecting 'Microphone' again. If that does not work, either reload this page or manually allow us to access your microphone (usually via a button next to your browser's address bar).",
 
   "sources-display": "Display",
   "sources-user": "Camera",

--- a/src/opencast.js
+++ b/src/opencast.js
@@ -54,7 +54,8 @@ export class Opencast {
   #currentUser = null;
 
   // The response from `/lti` or `null` if the request failed for some reason or
-  // if `this.#login !== true`.
+  // if `this.#login !== true`. Note though, that this can also be the empty
+  // object, indicating that there is no LTI session.
   #ltiSession = null;
 
   updateGlobalOc = null;

--- a/src/studio-state.js
+++ b/src/studio-state.js
@@ -5,10 +5,8 @@ import { createContext, useContext, useReducer } from 'react';
 import { isDisplayCaptureSupported, isUserCaptureSupported } from './util';
 
 
-export const MICROPHONE = 'microphone';
-export const MICROPHONE_REQUEST = 'microphone_request';
-export const NO_AUDIO = 'no-audio';
-export const NONE = 'none';
+export const AUDIO_SOURCE_MICROPHONE = 'microphone';
+export const AUDIO_SOURCE_NONE = 'none';
 
 export const VIDEO_SOURCE_BOTH = 'both';
 export const VIDEO_SOURCE_DISPLAY = 'display';
@@ -40,7 +38,7 @@ const initialState = () => ({
   userSupported: isUserCaptureSupported(),
 
   videoChoice: VIDEO_SOURCE_NONE,
-  audioChoice: NONE,
+  audioChoice: AUDIO_SOURCE_NONE,
 
   isRecording: false,
   prematureRecordingEnd: false,

--- a/src/style/global-style.js
+++ b/src/style/global-style.js
@@ -2,26 +2,30 @@ import css from '@emotion/css/macro'
 
 const GlobalStyle = css`
 * {
-    box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 html, body, button, input {
-    font-family: Ubuntu, Roboto, "Open Sans", "Segoe UI", "Helvetica Neue", Verdana, sans-serif;
+  font-family: Ubuntu, Roboto, "Open Sans", "Segoe UI", "Helvetica Neue", Verdana, sans-serif;
 }
 
 body {
-    overflow-x: hidden;
+  overflow-x: auto;
 }
 
 label, button:not(:disabled) {
-    cursor: pointer;
+  cursor: pointer;
 }
 
 button {
-    outline: none;
+  outline: none;
 }
 
 #root {
+  /* Of the most common mobile phones, the smallest viewport width is
+     320 (iPhone 5). */
+  min-width: 320px;
+  overflow-x: hidden;
   height: 100%;
 }
 

--- a/src/ui/studio/audio-setup/index.js
+++ b/src/ui/studio/audio-setup/index.js
@@ -105,7 +105,7 @@ export default function AudioSetup(props) {
         >
           { audioStream && devices.length > 0 && (
             <select
-              sx={{ variant: 'styles.select' }}
+              sx={{ variant: 'styles.select', my: 3, width: '90%' }}
               value={currentDeviceId}
               onChange={e => changeDevice(e.target.value)}
             >

--- a/src/ui/studio/audio-setup/index.js
+++ b/src/ui/studio/audio-setup/index.js
@@ -20,7 +20,7 @@ import {
 import { startAudioCapture, stopAudioCapture } from '../capturer';
 import { ActionButtons, StepContainer } from '../elements';
 import Notification from '../../notification';
-import { queryMediaDevices } from '../../../util';
+import { queryMediaDevices, getUniqueDevices } from '../../../util';
 
 import PreviewAudio from './preview-audio';
 
@@ -59,20 +59,7 @@ export default function AudioSetup(props) {
 
   // Stuff related to the device selection
   const currentDeviceId = audioStream?.getAudioTracks()?.[0]?.getSettings()?.deviceId;
-  let devices = [];
-  for (const d of state.mediaDevices) {
-    // Only intersted in audio inputs
-    if (d.kind !== 'audioinput') {
-      continue;
-    }
-
-    // If we already have a device with that device ID, we ignore it.
-    if (devices.some(od => od.deviceId === d.deviceId)) {
-      continue;
-    }
-
-    devices.push(d);
-  }
+  const devices = getUniqueDevices(state.mediaDevices, 'audioinput');
 
   // We write the currently used device ID to local storage to remember it
   // between visits of Studio.

--- a/src/ui/studio/audio-setup/index.js
+++ b/src/ui/studio/audio-setup/index.js
@@ -2,7 +2,7 @@
 /** @jsx jsx */
 import { jsx, Styled } from 'theme-ui';
 
-import { Container, Flex, Heading, Spinner, Text } from '@theme-ui/components';
+import { Flex, Heading, Spinner, Text } from '@theme-ui/components';
 import { useTranslation } from 'react-i18next';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faMicrophone, faMicrophoneSlash } from '@fortawesome/free-solid-svg-icons';
@@ -17,7 +17,7 @@ import {
 } from '../../../studio-state';
 
 import { startAudioCapture, stopAudioCapture } from '../capturer';
-import { ActionButtons } from '../elements';
+import { ActionButtons, StepContainer } from '../elements';
 import Notification from '../../notification';
 
 import PreviewAudio from './preview-audio';
@@ -51,15 +51,8 @@ export default function AudioSetup(props) {
   };
 
   return (
-    <Container
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        flex: '1 1 auto',
-        justifyContent: 'space-between',
-      }}
-    >
-      <Styled.h1 sx={{ textAlign: 'center' }}>{t('sources-audio-question')}</Styled.h1>
+    <StepContainer>
+      <Styled.h1>{t('sources-audio-question')}</Styled.h1>
       <Flex
         sx={{
           flexDirection: ['column', 'row'],
@@ -110,7 +103,7 @@ export default function AudioSetup(props) {
         prev={{ onClick: backToSetupVideo }}
         next={{ onClick: enterStudio, disabled: nextIsDisabled }}
       />
-    </Container>
+    </StepContainer>
   );
 }
 

--- a/src/ui/studio/audio-setup/preview-audio.js
+++ b/src/ui/studio/audio-setup/preview-audio.js
@@ -33,8 +33,6 @@ export default function PreviewAudio({ stream, ...props }) {
         width: '80%',
         height: '100px',
         bg: 'rgba(0,0,0,0.8)',
-        m: 3,
-        mb: 0,
         borderRadius: '7px',
        }}
     />

--- a/src/ui/studio/audio-setup/preview-audio.js
+++ b/src/ui/studio/audio-setup/preview-audio.js
@@ -1,13 +1,12 @@
 //; -*- mode: rjsx;-*-
 /** @jsx jsx */
-import { jsx, useThemeUI } from 'theme-ui';
+import { jsx } from 'theme-ui';
 
 import Oscilloscope from 'oscilloscope';
 import { useEffect, useRef } from 'react';
 
-export default function PreviewAudio({ stream, ...props }) {
+export default function PreviewAudio({ stream }) {
   const canvasRef = useRef();
-  const { theme } = useThemeUI();
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -24,14 +23,18 @@ export default function PreviewAudio({ stream, ...props }) {
       return () => scope.stop();
     }
     return () => {};
-  }, [theme.colors, stream]);
+  }, [stream]);
 
   return (
     <canvas
       ref={canvasRef}
+      width='800px'
+      height='200px'
       sx={{
-        width: '80%',
-        height: '100px',
+        width: '100%',
+        maxHeight: '200px',
+        minHeight: 0,
+        flex: '1 0 70px',
         bg: 'rgba(0,0,0,0.8)',
         borderRadius: '7px',
        }}

--- a/src/ui/studio/capturer.js
+++ b/src/ui/studio/capturer.js
@@ -19,13 +19,11 @@ export async function startAudioCapture(dispatch, deviceId = null) {
     });
 
     dispatch({ type: 'SHARE_AUDIO', payload: stream });
-    return true;
   } catch (err) {
     // TODO: there several types of exceptions; certainly we should differentiate here one day
     console.error('Error: ' + err);
 
     dispatch({ type: 'BLOCK_AUDIO' });
-    return false;
   }
 }
 

--- a/src/ui/studio/elements.js
+++ b/src/ui/studio/elements.js
@@ -218,13 +218,14 @@ export function VideoBox({ gap = 0, minWidth = 180, children }) {
 
       // One video below the other (col/column).
       const { colWidths, colHeights } = (() => {
+        const availableHeight = height - gap;
         const combinedAspectRatio =
           1 / ((1 / aspectRatios[0]) + (1 / aspectRatios[1]));
 
-        if (width > height * combinedAspectRatio) {
+        if (width > availableHeight * combinedAspectRatio) {
           // Children height perfectly matches container, extra space left and
           // right.
-          const width = height * combinedAspectRatio;
+          const width = availableHeight * combinedAspectRatio;
           return {
             colHeights: children.map((c, i) => (width / aspectRatios[i])),
             colWidths: Array(2).fill(width),

--- a/src/ui/studio/elements.js
+++ b/src/ui/studio/elements.js
@@ -10,6 +10,27 @@ import { useTranslation } from 'react-i18next';
 import React, { useRef, useState } from 'react';
 import equal from 'fast-deep-equal';
 
+
+// A full width flex container for some steps of the wizard.
+export const StepContainer = ({ children }) => (
+  <div
+    sx={{
+      display: 'flex',
+      flexDirection: 'column',
+      flex: '1 1 auto',
+      justifyContent: 'space-between',
+      p: 3,
+      pt: [2, 2, 3],
+      '& > h1': {
+        textAlign: 'center',
+        fontSize: ['24px', '27px', '32px'] ,
+      },
+    }}
+  >
+    { children }
+  </div>
+);
+
 // A div containing optional "back" and "next" buttons as well as the centered
 // children. The props `prev` and `next` are objects with the follwing fields:
 //

--- a/src/ui/studio/review/index.js
+++ b/src/ui/studio/review/index.js
@@ -3,10 +3,10 @@
 import { jsx, Styled } from 'theme-ui';
 
 import React, { useEffect } from 'react';
-import { Flex, Spinner, Text } from '@theme-ui/components';
+import { Spinner, Text } from '@theme-ui/components';
 import { useTranslation } from 'react-i18next';
 
-import { ActionButtons, VideoBox } from '../elements';
+import { ActionButtons, StepContainer, VideoBox } from '../elements';
 import { useStudioState, useDispatch } from '../../../studio-state';
 import Notification from '../../notification';
 
@@ -30,17 +30,8 @@ export default function Review(props) {
   };
 
   return (
-    <Flex
-      sx={{
-        flexDirection: 'column',
-        height: '100%',
-        flexGrow: 1,
-        padding: 3,
-      }}
-    >
-      <Styled.h1 sx={{ textAlign: 'center', fontSize: ['26px', '30px', '32px'] }}>
-        {t('review-heading')}
-      </Styled.h1>
+    <StepContainer>
+      <Styled.h1>{ t('review-heading') }</Styled.h1>
 
       { prematureRecordingEnd && (
         <Notification isDanger>
@@ -64,7 +55,7 @@ export default function Review(props) {
         }}
         next={{ onClick: handleNext }}
       />
-    </Flex>
+    </StepContainer>
   );
 };
 

--- a/src/ui/studio/video-setup/index.js
+++ b/src/ui/studio/video-setup/index.js
@@ -27,7 +27,7 @@ import {
   stopDisplayCapture,
   stopUserCapture
 } from '../capturer';
-import { ActionButtons } from '../elements';
+import { ActionButtons, StepContainer } from '../elements';
 import { SourcePreview } from './preview';
 import { loadCameraPrefs, loadDisplayPrefs, prefsToConstraints } from './prefs';
 
@@ -140,19 +140,8 @@ export default function VideoSetup({ nextStep, userHasWebcam }) {
     && !state.userUnexpectedEnd && !state.displayUnexpectedEnd;
 
   return (
-    <div
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        flex: '1 1 auto',
-        minHeight: 0,
-        p: 3,
-        pt: [2, 2, 3],
-      }}
-    >
-      <Styled.h1 sx={{ textAlign: 'center', fontSize: ['24px', '27px', '32px'] }}>
-        { title }
-      </Styled.h1>
+    <StepContainer>
+      <Styled.h1>{ title }</Styled.h1>
 
       { body }
 
@@ -166,7 +155,7 @@ export default function VideoSetup({ nextStep, userHasWebcam }) {
           label: 'sources-video-reselect-source',
         }}
       /> }
-    </div>
+    </StepContainer>
   );
 }
 

--- a/src/ui/studio/video-setup/index.js
+++ b/src/ui/studio/video-setup/index.js
@@ -19,6 +19,7 @@ import {
 } from '../../../studio-state';
 import { useSettings } from '../../../settings';
 
+import { queryMediaDevices } from '../../../util';
 import Notification from '../../notification';
 
 import {
@@ -266,8 +267,3 @@ const OptionButton = ({ icon, label, onClick, disabledText = false }) => {
 };
 
 const Spacer = (rest) => <div sx={{ flex: '1 0 0' }} {...rest}></div>;
-
-const queryMediaDevices = async (dispatch) => {
-  const devices = await navigator.mediaDevices.enumerateDevices();
-  dispatch({ type: 'UPDATE_MEDIA_DEVICES', payload: devices });
-};

--- a/src/ui/studio/video-setup/prefs.js
+++ b/src/ui/studio/video-setup/prefs.js
@@ -11,7 +11,7 @@ import { faTimes, faCog } from '@fortawesome/free-solid-svg-icons';
 import useResizeObserver from "use-resize-observer/polyfilled";
 
 import { useSettings } from '../../../settings';
-import { dimensionsOf } from '../../../util.js';
+import { dimensionsOf, getUniqueDevices } from '../../../util';
 import { useDispatch, useStudioState } from '../../../studio-state';
 import {
   startDisplayCapture,
@@ -334,20 +334,7 @@ const UserSettings = ({ updatePrefs, prefs }) => {
   const state = useStudioState();
 
   const currentDeviceId = deviceIdOf(state.userStream);
-  let devices = [];
-  for (const d of state.mediaDevices) {
-    // Only intersted in video inputs
-    if (d.kind !== 'videoinput') {
-      continue;
-    }
-
-    // If we already have a device with that device ID, we ignore it.
-    if (devices.some(od => od.deviceId === d.deviceId)) {
-      continue;
-    }
-
-    devices.push(d);
-  }
+  const devices =getUniqueDevices(state.mediaDevices, 'videoinput');
 
   const [width, height] = dimensionsOf(state.userStream);
   let arState;

--- a/src/ui/studio/video-setup/prefs.js
+++ b/src/ui/studio/video-setup/prefs.js
@@ -11,7 +11,7 @@ import { faTimes, faCog } from '@fortawesome/free-solid-svg-icons';
 import useResizeObserver from "use-resize-observer/polyfilled";
 
 import { useSettings } from '../../../settings';
-import { deviceIdOf, dimensionsOf } from '../../../util.js';
+import { dimensionsOf } from '../../../util.js';
 import { useDispatch, useStudioState } from '../../../studio-state';
 import {
   startDisplayCapture,
@@ -438,3 +438,6 @@ const RadioButton = ({ id, value, checked, name, onChange, label, state }) => {
     <label htmlFor={id}>{ label || value }</label>
   </Fragment>;
 };
+
+// Returns the devide ID of the video track of the given stream.
+export const deviceIdOf = stream => stream?.getVideoTracks()?.[0]?.getSettings()?.deviceId;

--- a/src/util.js
+++ b/src/util.js
@@ -42,9 +42,6 @@ export const dimensionsOf = stream => {
   return [width, height];
 };
 
-// Returns the devide ID of the video track of the given stream.
-export const deviceIdOf = stream => stream?.getVideoTracks()?.[0]?.getSettings()?.deviceId;
-
 // Converts the MIME type into a file extension.
 export const mimeToExt = mime => {
   if (mime) {
@@ -133,3 +130,9 @@ export const decodeHexString = hex => {
 
 // Returns a promise that resolves after `ms` milliseconds.
 export const sleep = ms => new Promise((resolve, reject) => setTimeout(resolve, ms));
+
+// Obtains all media devices and stores them into the global state.
+export const queryMediaDevices = async (dispatch) => {
+  const devices = await navigator.mediaDevices.enumerateDevices();
+  dispatch({ type: 'UPDATE_MEDIA_DEVICES', payload: devices });
+};

--- a/src/util.js
+++ b/src/util.js
@@ -136,3 +136,24 @@ export const queryMediaDevices = async (dispatch) => {
   const devices = await navigator.mediaDevices.enumerateDevices();
   dispatch({ type: 'UPDATE_MEDIA_DEVICES', payload: devices });
 };
+
+// Filters the `allDevices` array such that only devices with the given `kind`
+// are included and no two devices have the same `deviceId`.
+export const getUniqueDevices = (allDevices, kind) => {
+  let out = [];
+  for (const d of allDevices) {
+    // Only interested in one kind of device.
+    if (d.kind !== kind) {
+      continue;
+    }
+
+    // If we already have a device with that device ID, we ignore it.
+    if (out.some(od => od.deviceId === d.deviceId)) {
+      continue;
+    }
+
+    out.push(d);
+  }
+
+  return out;
+};


### PR DESCRIPTION
Closes #586 
Closes #399
Closes #395 

[**Deployed here**](https://test.studio.opencast.org/build-20200512185023-LukasKalbertodt-opencast-studio-000228-audio-device-select/)

This PR does two things:
- An audio device selector is added, very similar to the selector for video devices in that step. The last used device is stored in local storage and is thus remembered across visits.
- The audio step UI was changed such that it matches the video select UI more closely. The "no audio" step now immediately proceeds to step 3. Pressing the "microphone" button then visually removes the option buttons and show the audio preview and the device selector on their own.