### PR TITLE
Special-case the initial progress report

### DIFF
--- a/src/ui/studio/save-creation/index.js
+++ b/src/ui/studio/save-creation/index.js
@@ -120,10 +120,14 @@ export default function SaveCreation(props) {
         return;
       }
 
-      const lastProgress = progressHistory[progressHistory.length - 1];
-      const timeSinceLastUpdate = Date.now() - (lastProgress?.timestamp || 0);
-      if (timeSinceLastUpdate > 3000) {
-        onProgress(lastProgress.progress)
+      if (!progressHistory.length) {
+        onProgress(0);
+      } else {
+        const lastProgress = progressHistory[progressHistory.length - 1];
+        const timeSinceLastUpdate = Date.now() - lastProgress.timestamp;
+        if (timeSinceLastUpdate > 3000) {
+            onProgress(lastProgress.progress);
+        }
       }
     }, 1000);
 


### PR DESCRIPTION
Previously, the case of no preexisting progress history was handled
somewhat implicitly, which is at least error prone, and in this case
actually lead to a bug.

This patch handles that case explicitly, and simplifies the generic
case at the same time.

---

This fixes [Sentry issue 86](https://sentry.virtuos.uos.de/virtuos/opencast-studio/issues/364/).