### PR TITLE
Transition to TOML as configuration format & some other configuration changes

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -3,226 +3,144 @@
 Opencast Studio can be configured in three different ways:
 
 - the user can manually configure certain things on the settings page,
-- the server can provide a `settings.json` (only applicable if you deploy Studio yourself), and
+- the server can provide a `settings.toml` (only applicable if you deploy Studio yourself or as part of your Opencast), and
 - configuration values can be given via GET parameters in the URL.
 
 Settings configured by the user have the lowest priority and are overwritten by
-both, `settings.json` and GET parameters. GET parameters also override settings
-given in `settings.json`. Additionally, on the settings page, values that are
-already preconfigured via `settings.json` or a GET parameter are hidden from the
+both, `settings.toml` and GET parameters. GET parameters also override settings
+given in `settings.toml`. Additionally, on the settings page, values that are
+already preconfigured via `settings.toml` or a GET parameter are hidden from the
 user.
 
-The following settings are currently understood by Studio. The column "shown to user" means whether or not the user can configure this value on the settings page (only if this value is not configured via `settings.json` or a GET parameter, of course).
-
-<table>
-  <thead>
-    <tr>
-      <th>Name</th>
-      <th>Type</th>
-      <th>Example</th>
-      <th>Shown to user</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><b><code>opencast.serverUrl</code></b></td>
-      <td>string</td>
-      <td><code>https://develop.opencast.org</code></td>
-      <td>✔</td>
-    </tr>
-    <tr>
-      <td></td>
-      <td colspan="3">The server that recordings are uploaded to. Has to include <code>https://</code>. If this is set to an empty string, the domain Studio is deployed on is used.</td>
-    </tr>
-    <tr>
-      <td><b><code>opencast.loginName</code></b></td>
-      <td>string</td>
-      <td><code>peter</code></td>
-      <td>✔</td>
-    </tr>
-    <tr>
-      <td></td>
-      <td colspan="3">
-        Username of the Opencast user to authenticate as.
-      </td>
-    </tr>
-    <tr>
-      <td><b><code>opencast.loginPassword</code></b></td>
-      <td>string</td>
-      <td><code>verysecure123</code></td>
-      <td>✔</td>
-    </tr>
-    <tr>
-      <td></td>
-      <td colspan="3">
-        Password of the Opencast user to authenticate as.
-      </td>
-    </tr>
-    <tr>
-      <td><b><code>opencast.loginProvided</code></b></td>
-      <td>boolean</td>
-      <td><code>true</code></td>
-      <td>✘</td>
-    </tr>
-    <tr>
-      <td></td>
-      <td colspan="3">
-        If this is set to <code>true</code>, <code>loginPassword</code> and <code>loginName</code> are ignored. Instead, Studio assumes that the user's browser is already authenticated (via cookies) at the Opencast server URL. This pretty much only makes sense if studio is deployed on the same domain as the target Opencast server (e.g. in the path <code>/studio</code>).
-      </td>
-    </tr>
-    <tr>
-      <td><b><code>upload.seriesId</code></b></td>
-      <td>string</td>
-      <td><code>3fe9ea49-a671-4d1e-9669-0c96ff0f8f79</code></td>
-      <td>✘</td>
-    </tr>
-    <tr>
-      <td></td>
-      <td colspan="3">
-        The ID of the series which the recording is a part of. When uploading the recording, it is automatically associated with that series.
-      </td>
-    </tr>
-    <tr>
-      <td><b><code>upload.workflowId</code></b></td>
-      <td>string</td>
-      <td><code>fast</code></td>
-      <td>✘</td>
-    </tr>
-    <tr>
-      <td></td>
-      <td colspan="3">
-        The workflow ID used to process the recording.
-      </td>
-    </tr>
-    <tr>
-      <td><b><code>upload.acl</code></b></td>
-      <td>string or boolean</td>
-      <td><code>acl.xml</code></td>
-      <td>✘</td>
-    </tr>
-    <tr>
-      <td></td>
-      <td colspan="3">
-        Defines which ACL to send when uploading the recording. See below for more information.
-      </td>
-    </tr>
-    <tr>
-      <td><b><code>recording.mimes</code></b></td>
-      <td>array of strings</td>
-      <td><code>["video/mp4", "video/webm"]</code></td>
-      <td>✘</td>
-    </tr>
-    <tr>
-      <td></td>
-      <td colspan="3">
-        A list of preferred MIME types used by the media recorder. Studio uses the first MIME type in that list for which <code>MediaRecorder.isTypeSupported</code> returns <code>true</code>. If none of the specified ones is supported or if the browser does not support <code>isTypeSupported</code>, then Studio lets the browser choose a MIME-type.
-      </td>
-    </tr>
-    <tr>
-      <td><b><code>recording.videoBitrate</code></b></td>
-      <td>positive integer</td>
-      <td><code>2000000</code></td>
-      <td>✘</td>
-    </tr>
-    <tr>
-      <td></td>
-      <td colspan="3">
-        The target video bitrate of the recording in bits per second. Please note that specifying this for all users is usually a bad idea, as the video stream and situation is different for everyone. The resulting quality also largely depends on the browser's encoder.
-      </td>
-    </tr>
-    <tr>
-      <td><b><code>display.maxHeight</code></b></td>
-      <td>positive integer</td>
-      <td><code>1080</code></td>
-      <td>✘</td>
-    </tr>
-    <tr>
-      <td></td>
-      <td colspan="3">
-        Passed as <code>height: { max: _ }</code> <code>MediaStreamConstraint</code> to <code>getDisplayMedia</code>. Resolutions larger than that should be scaled down by the browser.
-      </td>
-    </tr>
-    <tr>
-      <td><b><code>display.maxFps</code></b></td>
-      <td>positive integer</td>
-      <td><code>30</code></td>
-      <td>✘</td>
-    </tr>
-    <tr>
-      <td></td>
-      <td colspan="3">
-        Passed as <code>framerate: { max: _ }</code> <code>MediaStreamConstraint</code> to <code>getDisplayMedia</code>. Most browsers capture with a maximum of 30 FPS by default anyway, so you might not need this.
-      </td>
-    </tr>
-    <tr>
-      <td><b><code>camera.maxHeight</code></b></td>
-      <td>positive integer</td>
-      <td><code>480</code></td>
-      <td>✘</td>
-    </tr>
-    <tr>
-      <td></td>
-      <td colspan="3">
-        Passed as <code>height: { max: _ }</code> <code>MediaStreamConstraint</code> to <code>getUserMedia</code>. Different maximum heights can affect the aspect ratio of the video.
-      </td>
-    </tr>
-    <tr>
-      <td><b><code>camera.maxFps</code></b></td>
-      <td>positive integer</td>
-      <td><code>30</code></td>
-      <td>✘</td>
-    </tr>
-    <tr>
-      <td></td>
-      <td colspan="3">
-        Passed as <code>framerate: { max: _ }</code> <code>MediaStreamConstraint</code> to <code>getUserMedia</code>. Setting this might lead to some users not being able to share their webcam!
-      </td>
-    </tr>
-    <tr>
-      <td><b><code>review.disableCutting</code></b></td>
-      <td>boolean</td>
-      <td><code>true</code></td>
-      <td>✘</td>
-    </tr>
-    <tr>
-      <td></td>
-      <td colspan="3">
-        Disables and hides the cutting tools from the review page when set to <code>true</code>. By default, this is <code>false</code>. It only makes sense to set this to <code>true</code> if your workflows can't handle the cutting information (SMIL file). The default Studio worflow in Opencast 8.4 and newer supports this.
-      </td>
-    </tr>
-  </tbody>
-</table>
+**Backwards compatibility note:** in previous versions, `settings.toml` was
+`settings.json`. JSON settings are now deprecated, but are still supported until
+Studio drops support for Opencast 8. To continue using the JSON configuration
+file, you have to specify `REACT_APP_SETTINGS_PATH` and it has to end with
+`.json`. This is correctly set in the released versions for Opencast 8.
 
 
-**Note**: all data configured via `settings.json` is as public as your Studio installation. For example, if your students can access your deployed studio app, they can also see the `settings.json`. This is particularly important if you want to preconfigure an Opencast user.
+## Possible configuration values
 
-Please also note that all settings related to video capture or recording should be treated carefully. Setting any of those means that you know better than the user's browser, which is unlikely as the browser has exact information about screen resolution, connected cameras, CPU usage and the like. So before setting those for all of your users, make sure to test those settings first!
+The following settings are currently understood and respected by Studio. This
+code block shows the TOML configuration, but all values can be specified as GET
+parameter as well. See further below for information on that.
+
+```toml
+# Configuration for Opencast Studio.
+#
+# Is loaded by Studio in the beginning. Default path is "settings.toml"
+# (relative to current URL), but can be overwritten via the environment variable
+# `REACT_APP_SETTINGS_PATH` at build time.
 
 
-### Example `settings.json`
+[opencast]
+# URL of the Opencast server that recordings are uploaded to. Has to include
+# `https://`. If this is set to an empty string, Studio uses the domain it is
+# deployed on. This mostly makes sense for Studio integrated into Opencast. If
+# this value is not defined, the user can specify the server URL on the settings
+# page.
+#serverUrl = "https://opencast.my-university.net"
 
-```json
-{
-  "opencast": {
-    "serverUrl": "https://develop.opencast.org"
-  },
-  "upload": {
-    "workflowId": "fast",
-    "seriesId": "3fe9ea49-a671-4d1e-9669-0c96ff0f8f79",
-  }
-}
+# Username of the Opencast user to authenticate as. Specifying this value in
+# this configuration file is rarely useful, but it can be used if a proper user
+# authentication can't be implemented and you want all Studio users to use the
+# same Opencast user. This is not ideal and should be avoided, though.
+#
+# If this value is undefined and `loginProvided` (see below) is NOT `true`, the
+# Studio user can configure the login name on the Studio settings page.
+#loginName = "peter"
+
+# Password of the Opencast user to authenticate as. See `loginName` for more
+# information on when specifying this value is useful. BE AWARE that a password
+# specified in the Studio configuration file is as public as your Studio
+# installation: if a user can access Studio, they can access this password. As
+# such, specifying a pasword in the config file should be avoided if possible.
+#loginPassword = "aligator"
+
+# If this is set to `true`, `loginPassword` and `loginName` are ignored.
+# Instead, Studio assumes that the user's browser is already authenticated (via
+# cookies) at the Opencast server URL. This pretty much only makes sense if
+# studio is deployed on the same domain as the target Opencast server (e.g. at
+# `/studio`). Default: false.
+#loginProvided = true
+
+
+[upload]
+# The ID of the series which the recording is a part of. When uploading the
+# recording, it is automatically associated with that series. This value is
+# mostly passed as GET parameter; specifying it in the configuration file only
+# makes sense if you want all the Studio uploads (that don't specify a series
+# otherwise) to be associated with one series.
+#seriesId = "979e0a0b-db25-47cd-869a-10daa1b3eb7a"
+
+# The workflow ID used to process the recording.
+#workflowId = "studio-upload"
+
+# Defines which ACL to send when uploading the recording.
+#acl = false
+
+
+[recording]
+# A list of preferred MIME types used by the media recorder. Studio uses the
+# first MIME type in that list for which `MediaRecorder.isTypeSupported` returns
+# `true`. If this is not defined, or if none of the specified MIME-types is
+# supported or if the browser does not support `isTypeSupported`, then Studio
+# lets the browser choose a MIME-type.
+#mimes = ["video/mp4", "video/webm"]
+
+# The target video bitrate of the recording in bits per second. Please note that
+# specifying this for all users is usually a bad idea, as the video stream and
+# situation is different for everyone. The resulting quality also largely
+# depends on the browser's encoder.
+#videoBitrate = 2000000
+
+
+[review]
+# Disables and hides the cutting tools from the review page when set to `true`.
+# By default, this is `false`. It only makes sense to set this to `true` if your
+# workflows can't handle the cutting information (SMIL file). The default Studio
+# worflow in Opencast 8.4 and newer supports this.
+#disableCutting = true
+
+
+[display]
+# Passed as `height: { max: _ }` `MediaStreamConstraint` to `getDisplayMedia`.
+# Resolutions larger than that should be scaled down by the browser.
+#maxHeight = 720
+
+# Passed as `framerate: { max: _ }` `MediaStreamConstraint` to
+# `getDisplayMedia`. Most browsers capture with a maximum of 30 FPS by default
+# anyway, so you probably don't need this.
+#maxFps = 30
+
+
+[camera]
+# Passed as `height: { max: _ }` `MediaStreamConstraint` to `getUserMedia`.
+# Different maximum heights can affect the aspect ratio of the video.
+#maxHeight = 480
+
+# Passed as `framerate: { max: _ }` `MediaStreamConstraint` to `getUserMedia`.
+# Setting this might lead to some users not being able to share their webcam!
+#maxFps = 30
 ```
 
-### Example GET Parameters
 
-GET parameters can simply be attached to the studio URL if the form `…/?option1=value1&option2=value2&…`.
-They are an easy way to provide a link with specific settings to someone.
-An example of such a link would be:
+**Note**: all data configured via `settings.toml` is as public as your Studio installation. For example, if your students can access your deployed studio app, they can also see the `settings.toml`. This is particularly important if you want to preconfigure an Opencast user.
+
+Please also note that all settings related to video capture or recording should be treated carefully. Setting any of those means that you know more than the user's browser, which is unlikely: the browser has exact information about screen resolution, connected cameras, CPU usage and the like. As such, before setting any of those values for all of your users, make sure to test everything first!
+
+
+## Specifying settings via GET Parameters
+
+GET parameters can simply be attached to the studio URL. Values specified this way overwrite values set by the user or by `settings.toml`. Example URL:
 
 ```
-https://studio.opencast.org/?opencast.serverUrl=https://develop.opencast.org&upload.workflowId=fast&upload.seriesId=3fe9ea49-a671-4d1e-9669-0c96ff0f8f79
+https://studio.opencast.org/?opencast.serverUrl=https://develop.opencast.org&upload.workflowId=studio-upload&upload.seriesId=3fe9ea49-a671-4d1e-9669-0c96ff0f8f79
 ```
 
+Note that each key is a "path" like `opencast.serverUrl`. The first part of that path is the "section" in the TOML file shown above (e.g. `[opencast]`).
+
+TODO
 You can also include your configuration in a JSON object, encode it as UTF-8 string then encode that as hex string and pass it with the `config=` GET parameter. This might help to avoid problems if URLs (and thus the GET parameters) are processed (e.g. by an LMS) in a way that modifies special characters. For example:
 
 - Stringified JSON: `{"opencast":{"loginProvided":true}}`
@@ -240,30 +158,30 @@ You can encode your JSON string as hex string with [this tool](https://onlineutf
 Note that this can't be used with other GET parameters. If `config=` is specified, all other parameters are ignored.
 
 
-### Debugging/Help
+## Debugging/Help
 
 To check if your configuration is correctly applied, you can open Studio in your browser and open the developer tools console (via F12). Studio prints the merged settings and the current state of the connection to the Opencast server there.
 
-You can also check the "Network" tab in the browser's dev tools. There you can see where Studio tries to fetch `settings.json` and your ACL template from and what your server returned.
+You can also check the "Network" tab in the browser's dev tools. There you can see where Studio tries to fetch `settings.toml` and your ACL template from and what your server returned.
 
 
 ### Specify ACL
 
-With `upload.acl` you can configure which ACL are sent (as an attachment) to the Opencast server when uploading. Possible values:
+With `upload.acl` you can configure which ACL is sent (as an attachment) to the Opencast server when uploading. Possible values:
 - `true`: use the default ACL (this is the default behavior)
 - `false`: do not send an ACL when uploading
-- Path to XML template (e.g. `acl.xml` or `/config/acl.xml`). A path to an XML file specifying the ACL. If the path starts with `/` it is considered absolute on the current server and `server.url${path}` is loaded. If it doesn't start with `/`, `server.url/$PUBLIC_URL/${path}` is loaded.
+- Path to XML template (e.g. `acl.xml` or `/config/acl.xml`). A path to an XML file specifying the ACL. If the path starts with `/` it is considered absolute on the current server and `server.url${path}` is loaded. If it doesn't start with `/`, `server.url/${PUBLIC_URL}/${path}` is loaded.
 
 The ACL XML template is a Mustache template. The following variables are passed as view:
 
-- `userName`: the username of the currnet user (e.g. `admin`)
-- `userRole`: the user role of the current user (e.g. `ROLE_USER_ADMIN`)
-- `roleOAuthUser`: `"ROLE_OAUTH_USER"` if this role is in `user.roles` or `undefined` otherwise
+- `userName`: the username of the currnet user (e.g. `admin`).
+- `userRole`: the user role of the current user (e.g. `ROLE_USER_ADMIN`).
+- `roleOAuthUser`: `"ROLE_OAUTH_USER"` if this role is in `user.roles` or `undefined` otherwise.
 - `ltiCourseId`: the `context_id` taken from the `/lti` endpoint or `undefined` if the field does not exist.
 - `defaultReadRoles`: a convenience array of roles that usually have read access. Always contains `userRole`. If `ltiCourseId` is defined, also contains `"${ltiCourseId}_Learner"` and `"${ltiCourseId}_Instructor"`.
 - `defaultWriteRoles`: a convenience array of roles that usually have read access. Always contains `userRole`. If `ltiCourseId` is defined, also contains `"${ltiCourseId}_Instructor"`.
 
-The default ACL definition template simply gives read and write access to `userRole`:
+The default ACL template simply gives read and write access to `userRole`:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -12,12 +12,6 @@ given in `settings.toml`. Additionally, on the settings page, values that are
 already preconfigured via `settings.toml` or a GET parameter are hidden from the
 user.
 
-**Backwards compatibility note:** in previous versions, `settings.toml` was
-`settings.json`. JSON settings are now deprecated, but are still supported until
-Studio drops support for Opencast 8. To continue using the JSON configuration
-file, you have to specify `REACT_APP_SETTINGS_PATH` and it has to end with
-`.json`. This is correctly set in the released versions for Opencast 8.
-
 
 ## Possible configuration values
 
@@ -159,13 +153,6 @@ You can also put the settings in TOML file, then encode that as a hex string and
 You can encode your TOML as hex string with [this tool](https://onlineutf8tools.com/convert-utf8-to-hexadecimal), for example. Be sure to disable the options "Use Hex Radix Prefix" and "Use Extra Spacing".
 
 Note that if `config=` is specified, all other parameters are ignored!
-
-**Backwards compatibility note:** in previous versions, this parameter was an
-encoded JSON object instead of TOML. Passing JSON in this way is now deprecated,
-but ist still supported until Studio drops support for Opencast 8. As all
-stringified JSON objects have to start with `{` and TOML cannot start with `{`,
-Studio has an easy way to see whether your parameter is JSON or TOML. But again:
-JSON support is dropped in future versions and you are encouraged to use TOML.
 
 
 ## Debugging/Help

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -72,8 +72,16 @@ parameter as well. See further below for information on that.
 # The workflow ID used to process the recording.
 #workflowId = "studio-upload"
 
-# Defines which ACL to send when uploading the recording.
+# Defines which ACL to send when uploading the recording. See
+# `CONFIGURATION.md` for more information.
 #acl = false
+# -OR-
+#acl = """
+#<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+#<Policy ...>
+#  ...
+#</Policy>
+#"""
 
 
 [recording]
@@ -161,7 +169,7 @@ Note that if `config=` is specified, all other parameters are ignored!
 
 To check if your configuration is correctly applied, you can open Studio in your browser and open the developer tools console (via F12). Studio prints the merged settings and the current state of the connection to the Opencast server there.
 
-You can also check the "Network" tab in the browser's dev tools. There you can see where Studio tries to fetch `settings.toml` and your ACL template from and what your server returned.
+You can also check the "Network" tab in the browser's dev tools. There you can see where Studio tries to fetch `settings.toml` from and what your server returned.
 
 
 ### Specify ACL
@@ -169,9 +177,10 @@ You can also check the "Network" tab in the browser's dev tools. There you can s
 With `upload.acl` you can configure which ACL is sent (as an attachment) to the Opencast server when uploading. Possible values:
 - `true`: use the default ACL (this is the default behavior)
 - `false`: do not send an ACL when uploading
-- Path to XML template (e.g. `acl.xml` or `/config/acl.xml`). A path to an XML file specifying the ACL. If the path starts with `/` it is considered absolute on the current server and `server.url${path}` is loaded. If it doesn't start with `/`, `server.url/${PUBLIC_URL}/${path}` is loaded.
+- A string containing a valid ACL XML template (note the `"""` multi line string in TOML)
 
-The ACL XML template is a Mustache template. The following variables are passed as view:
+The ACL XML template is a [Mustache template](https://mustache.github.io/mustache.5.html).
+The following variables are passed as view:
 
 - `userName`: the username of the currnet user (e.g. `admin`).
 - `userRole`: the user role of the current user (e.g. `ROLE_USER_ADMIN`).

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -140,22 +140,32 @@ https://studio.opencast.org/?opencast.serverUrl=https://develop.opencast.org&upl
 
 Note that each key is a "path" like `opencast.serverUrl`. The first part of that path is the "section" in the TOML file shown above (e.g. `[opencast]`).
 
-TODO
-You can also include your configuration in a JSON object, encode it as UTF-8 string then encode that as hex string and pass it with the `config=` GET parameter. This might help to avoid problems if URLs (and thus the GET parameters) are processed (e.g. by an LMS) in a way that modifies special characters. For example:
+You can also put the settings in TOML file, then encode that as a hex string and pass it with the `config=` GET parameter. This might help to avoid problems if URLs (and thus the GET parameters) are processed (e.g. by an LMS) in a way that modifies special characters. For example:
 
-- Stringified JSON: `{"opencast":{"loginProvided":true}}`
+- TOML string:
+  ```
+  [opencast]
+  loginProvided = true
+  ```
 - Encoded as hex string:
   ```
-  7B226F70656E63617374223A7B226C6F67696E50726F7669646564223A747275657D7D
+  5b6f70656e636173745d0a6c6f67696e50726f7669646564203d2074727565
   ```
 - Pass to Studio:
   ```
-  https://studio.opencast.org?config=7B226F70656E63617374223A7B226C6F67696E50726F7669646564223A747275657D7D
+  https://studio.opencast.org?config=5b6f70656e636173745d0a6c6f67696e50726f7669646564203d2074727565
   ```
 
-You can encode your JSON string as hex string with [this tool](https://onlineutf8tools.com/convert-utf8-to-hexadecimal), for example. Be sure to disable the options "Use Hex Radix Prefix" and "Use Extra Spacing".
+You can encode your TOML as hex string with [this tool](https://onlineutf8tools.com/convert-utf8-to-hexadecimal), for example. Be sure to disable the options "Use Hex Radix Prefix" and "Use Extra Spacing".
 
-Note that this can't be used with other GET parameters. If `config=` is specified, all other parameters are ignored.
+Note that if `config=` is specified, all other parameters are ignored!
+
+**Backwards compatibility note:** in previous versions, this parameter was an
+encoded JSON object instead of TOML. Passing JSON in this way is now deprecated,
+but ist still supported until Studio drops support for Opencast 8. As all
+stringified JSON objects have to start with `{` and TOML cannot start with `{`,
+Studio has an easy way to see whether your parameter is JSON or TOML. But again:
+JSON support is dropped in future versions and you are encouraged to use TOML.
 
 
 ## Debugging/Help

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -1,5 +1,7 @@
 # Configuration
 
+> **Note**: this is the documentation on the `master` branch, targetting Opencast 9. If you are interested in documentation about the Studio version that shipped with the current stable Opencast 8, please see [the `opencast-8` branch](https://github.com/elan-ev/opencast-studio/blob/opencast-8/CONFIGURATION.md).
+
 Opencast Studio can be configured in three different ways:
 
 - the user can manually configure certain things on the settings page,

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ npm run build
 | Option                            | Example            | Description
 | --------------------------------- | ------------------ | -----------
 | `PUBLIC_URL`                      | `/studio`          | Path from which Studio will be served
-| `REACT_APP_SETTINGS_PATH`         | `/mysettings.json` | Path from which to load the configuration
+| `REACT_APP_SETTINGS_PATH`         | `/mysettings.toml` | Path from which to load the configuration (see `CONFIGURATION.md` for more information)
 | `REACT_APP_INCLUDE_LEGAL_NOTICES` | `1`                | Set to `1` to include legal notices and information about ELAN e.V., any other value or having this variable not set will not include them. Unless you are working for ELAN e.V. there is probably no reason for you to use this variable.
 
 

--- a/create-release.sh
+++ b/create-release.sh
@@ -23,13 +23,25 @@ tar -czf ../$FILENAME *
 cd ..
 
 
-# Build integrated version
+# Build integrated version for Opencast 8.x
 rm -rf build/
 export PUBLIC_URL=/studio
 export REACT_APP_SETTINGS_PATH="/ui/config/studio/settings.json"
 npm run build
 
-FILENAME="oc-studio-$(date --utc +%F)-integrated.tar.gz"
+FILENAME="oc-studio-$(date --utc +%F)-integrated-8.tar.gz"
+cd build
+tar -czf ../$FILENAME *
+cd ..
+
+
+# Build integrated version for Opencast 9.x
+rm -rf build/
+export PUBLIC_URL=/studio
+export REACT_APP_SETTINGS_PATH="/ui/config/studio/settings.toml"
+npm run build
+
+FILENAME="oc-studio-$(date --utc +%F)-integrated-9.tar.gz"
 cd build
 tar -czf ../$FILENAME *
 cd ..

--- a/create-release.sh
+++ b/create-release.sh
@@ -23,25 +23,13 @@ tar -czf ../$FILENAME *
 cd ..
 
 
-# Build integrated version for Opencast 8.x
-rm -rf build/
-export PUBLIC_URL=/studio
-export REACT_APP_SETTINGS_PATH="/ui/config/studio/settings.json"
-npm run build
-
-FILENAME="oc-studio-$(date --utc +%F)-integrated-8.tar.gz"
-cd build
-tar -czf ../$FILENAME *
-cd ..
-
-
-# Build integrated version for Opencast 9.x
+# Build integrated version
 rm -rf build/
 export PUBLIC_URL=/studio
 export REACT_APP_SETTINGS_PATH="/ui/config/studio/settings.toml"
 npm run build
 
-FILENAME="oc-studio-$(date --utc +%F)-integrated-9.tar.gz"
+FILENAME="oc-studio-$(date --utc +%F)-integrated.tar.gz"
 cd build
 tar -czf ../$FILENAME *
 cd ..

--- a/package-lock.json
+++ b/package-lock.json
@@ -1634,6 +1634,11 @@
         "@hapi/hoek": "^8.3.0"
       }
     },
+    "@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
+    },
     "@jest/console": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.13.1",
     "@fortawesome/free-solid-svg-icons": "^5.13.1",
     "@fortawesome/react-fontawesome": "^0.1.11",
+    "@iarna/toml": "^2.2.5",
     "@sentry/browser": "^5.18.1",
     "@testing-library/jest-dom": "^5.11.0",
     "@testing-library/react": "^9.5.0",

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,8 @@ if (process.env.REACT_APP_ENABLE_SENTRY === '1') {
   });
 }
 
-// Load the rest of the application and try to fetch the `settings.json`.
+// Load the rest of the application and try to fetch the settings file from the
+// server.
 const initialize = Promise.all([
   // Load rest of the application code
   import('./App').then(mod => mod.default),


### PR DESCRIPTION
Closes #535 
Closes #558 
Partially unblocks #480 

As discussed in #535 the only alternative options were TOML and YAML. There was some discussion without clear result. I applied the "Being Pragmatic" rule from the contribution guidelines and just picked TOML. It has the clear technical advantage of having a significantly smaller parser which improves app loading times. Furthermore, I can't imagine anyone having problems with modifying the example TOML file (given in `CONFIGURATION.md`) to their liking.

~~Notes about backwards compatibility: This would in theory be a breaking change. But as we still want to support Opencast 8, we can't break the configuration. As such, JSON is still allowed! To use a JSON config file, `REACT_APP_SETTINGS_PATH` has to be set and end with `.json`. This is done in the release scripts for the OC 8 release. For the GET parameter `config`, JSON can be used, too.
I plan on dropping this deprecated JSON support as soon as we target OC 9.~~

**This is a breaking change!**

CC @lkiesow @mtneug @JulianKniephoff 