### PR TITLE
Add possibility to show and configure a "go back" button in final step

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -126,6 +126,19 @@ parameter as well. See further below for information on that.
 # Passed as `framerate: { max: _ }` `MediaStreamConstraint` to `getUserMedia`.
 # Setting this might lead to some users not being able to share their webcam!
 #maxFps = 30
+
+[return]
+# If this key is set, a "exit and back" button is shown in the last dialog
+# right above the "start a new recording" button. This button links to the
+# value of this key. Setting this value is usually done via GET parameters, as
+# a global configuration often does not make sense. You also probably want to
+# set `return.label`.
+#target = "https://my-lsm.me.com/course?id=123"
+
+# Label for the site that `return.target` links to. Usually the name of your
+# LMS. The English button label is "Exit and go back to {{return.label}}". This
+# value is only used if `return.target` is set!
+#label = "Stud.IP"
 ```
 
 

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -38,6 +38,8 @@
   "save-creation-warn-session-expired": "Es scheint, als wäre Ihre Opencast-Sitzung abgelaufen. Um diese zu erneuern, versuchen Sie <1>die Webseite, von der Sie Opencast Studio gestartet haben,</1> in einem anderen Browser-Tab zu öffnen und hierher zurückzukehren.",
   "save-creation-warn-login-failed": "Die Anmeldung beim Opencast-Server schlug fehl. Bitte prüfen Sie Ihre Anmeldedaten in <1>den Einstellungen</1>.",
 
+  "save-creation-return-to": "Beenden und zurück ({{label}})",
+  "save-creation-return-to-no-label": "Beenden und zurück zur vorherigen Seite",
   "save-creation-new-recording": "Neue Aufzeichnung starten",
   "save-creation-new-recording-warning": "Wenn Sie eine neue Aufzeichnung starten, werden die derzeitigen Aufzeichnungen in dieser Applikation verworfen (herunter- oder hochgeladene Aufzeichnung bleiben aber erhalten). Sind Sie sicher?",
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -36,6 +36,8 @@
   "save-creation-warn-session-expired": "It seems like your Opencast session has expired. To refresh the session, try opening <1>the website from which you started Opencast Studio</1> in another browser tab and return here.",
   "save-creation-warn-login-failed": "Logging into the Opencast server failed. Please check your login credentials in <1>the settings</1>.",
 
+  "save-creation-return-to": "Exit and go back to {{label}}",
+  "save-creation-return-to-no-label": "Exit and go back to previous page",
   "save-creation-new-recording": "Start a new recording",
   "save-creation-new-recording-warning": "By starting a new recording, the current recordings will be discarded in this application (uploaded or download recordings are not affected). Are you sure?",
   "share-desktop": "Share desktop",

--- a/src/settings.js
+++ b/src/settings.js
@@ -446,10 +446,19 @@ const SCHEMA = {
     maxFps: types.positiveInteger,
     maxHeight: types.positiveInteger,
   },
+  return: {
+    label: types.string,
+    target: (v, allowParse) => {
+      types.string(v, allowParse);
+      if (!(v.startsWith('/') || v.startsWith('http'))) {
+        throw new Error(`has to start with '/' or 'http'`);
+      }
+    },
+  },
 };
 
 
-// Custumize array merge behavior
+// Customize array merge behavior
 let merge = (a, b) => {
   return deepmerge(a, b, { arrayMerge });
 };

--- a/src/ui/studio/save-creation/index.js
+++ b/src/ui/studio/save-creation/index.js
@@ -8,6 +8,7 @@ import {
   faUpload,
   faRedoAlt,
   faExclamationTriangle,
+  faTimesCircle,
 } from '@fortawesome/free-solid-svg-icons';
 import { Button, Box, Container, Spinner, Text } from '@theme-ui/components';
 import { Fragment, useEffect, useState } from 'react';
@@ -174,14 +175,6 @@ export default function SaveCreation(props) {
     }
   }
 
-  const handleNewRecording = () => {
-    const doIt = window.confirm(t('save-creation-new-recording-warning'));
-    if (doIt) {
-      dispatch({ type: 'RESET' });
-      props.firstStep();
-    }
-  };
-
   const allDownloaded = recordings.every(rec => rec.downloaded);
   const possiblyDone = (uploadState.state === STATE_UPLOADED || allDownloaded)
     && uploadState.state !== STATE_UPLOADING;
@@ -253,20 +246,61 @@ export default function SaveCreation(props) {
           disabled: false,
         }}
       >
-        { !possiblyDone ? null : (
-          <Button
-            sx={{ whiteSpace: 'nowrap' }}
-            title={t('save-creation-new-recording')}
-            onClick={handleNewRecording}
-          >
-            <FontAwesomeIcon icon={faRedoAlt} />
-            {t('save-creation-new-recording')}
-          </Button>
-        )}
+        { possiblyDone && <PostAction
+          goToFirstStep={props.firstStep}
+        />}
       </ActionButtons>
     </Container>
   );
 }
+
+const PostAction = ({ goToFirstStep }) => {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const settings = useSettings();
+
+  const handleNewRecording = () => {
+    const doIt = window.confirm(t('save-creation-new-recording-warning'));
+    if (doIt) {
+      dispatch({ type: 'RESET' });
+      goToFirstStep();
+    }
+  };
+
+  let returnAction;
+  if (settings.return?.target) {
+    const label = settings.return?.label
+      ? t('save-creation-return-to', { label: settings.return.label })
+      : t('save-creation-return-to-no-label');
+
+    returnAction = (
+      <Button
+        as='a'
+        title={label}
+        href={settings.return.target}
+        sx={{ whiteSpace: 'nowrap', fontWeight: 400, mb: 2 }}
+      >
+        <FontAwesomeIcon icon={faTimesCircle} />
+        { label }
+      </Button>
+    );
+  }
+
+  return (
+    <div sx={{ display: 'flex', flexDirection: 'column' }}>
+      { returnAction }
+
+      <Button
+        sx={{ whiteSpace: 'nowrap' }}
+        title={t('save-creation-new-recording')}
+        onClick={handleNewRecording}
+      >
+        <FontAwesomeIcon icon={faRedoAlt} />
+        {t('save-creation-new-recording')}
+      </Button>
+    </div>
+  );
+};
 
 const DownloadBox = ({ presenter, title }) => {
   const { t } = useTranslation();


### PR DESCRIPTION
Closes #593 

Often, Studio feels somewhat like a dead end. In the end, the user is
just offered to record a new recording. But usually, the user wants to
leave or return to the page they are coming from. This commit makes
that possible.

We might want to have a better solution for when Studio is opened in a new tab still.

For the record: I decided against a solution that uses or can be configured to use `document.referrer`. While passing `return.target=referrer` looks good, relying on the referrer is a fragile solution. The referrer can get lost for a couple of reasons. Additionally, the referrer can be unexpected -- for example, Opencast might forward `/studio` to the login page when the user is not authenticated, meaning that the login page will be the referrer. We can always add the `referrer` option later when people really want it, but I don't think it's a great idea.