### PR TITLE
Clear retry timeout in last step when Opencast cannot be reached

### DIFF
--- a/src/ui/studio/save-creation/index.js
+++ b/src/ui/studio/save-creation/index.js
@@ -413,11 +413,13 @@ const NotConnectedWarning = () => {
   const [retrying, setRetrying] = useState(false);
   useEffect(() => {
     if (!opencast.isReadyToUpload() && !retrying && isVisible) {
-      setTimeout(async () => {
+      const id = setTimeout(async () => {
         setRetrying(true);
         await opencast.refreshConnection();
         setRetrying(false);
       }, 5000);
+
+      return () => clearTimeout(id);
     }
   })
 


### PR DESCRIPTION
This fixes #675 as the timeout used the old `opencast` instance which
contained old data and would then overwrite the current instance with
the old one.