### PR TITLE
Fix an error when there is no `upload` configuration

### DIFF
--- a/src/ui/studio/save-creation/index.js
+++ b/src/ui/studio/save-creation/index.js
@@ -355,7 +355,7 @@ const UploadForm = ({ uploadState, handleUpload }) => {
   const {
     titleField = FORM_FIELD_REQUIRED,
     presenterField = FORM_FIELD_REQUIRED,
-  } = useSettings().upload;
+  } = useSettings().upload || {};
 
   const { t } = useTranslation();
   const opencast = useOpencast();


### PR DESCRIPTION
The error looks something like this: https://sentry.virtuos.uos.de/virtuos/opencast-studio/issues/393