### PR TITLE
Fix label for "remove cut" buttons

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -100,7 +100,7 @@
   "review-no-end": "Kein Ende festgelegt",
   "review-set-start": "Aktuelle Zeit als Anfang festlegen",
   "review-set-end": "Aktuelle Zeit als Ende festlegen",
-  "review-remove-start-end": "Entfernen",
+  "review-remove-cut-point": "Entfernen",
   "review-part-will-be-removed": "Dieser Teil wird entfernt",
   "review-play": "Abspielen",
   "review-pause": "Pausieren",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -102,7 +102,7 @@
   "review-no-end": "No end set",
   "review-set-start": "Set current time as start",
   "review-set-end": "Set current time as end",
-  "review-remove-start-end": "Remove",
+  "review-remove-cut-point": "Remove",
   "review-part-will-be-removed": "This part will be removed",
   "review-player-progress": "{{currentTime, duration-seconds}} / {{duration, duration-seconds}}",
   "review-play": "Play",

--- a/src/ui/studio/review/index.js
+++ b/src/ui/studio/review/index.js
@@ -277,7 +277,7 @@ const CutControls = (
             previewController.current.currentTime = value;
           }} />
         </Trans>
-        <IconButton title={t(`review-remove-${marker}-end`)} onClick={
+        <IconButton title={t(`review-remove-cut-point`, { context: marker })} onClick={
           () => recordingDispatch({
             type: `UPDATE_${marker.toUpperCase()}`,
             payload: null,


### PR DESCRIPTION
I am not sure what the initial intention was here, but I guess we don't
really need different labels for the two different buttons. Helps
keeping the translation strings to a minimum. Before this commit, the
"remove end" button did not have any translation and showed the
translation key.

