### PR TITLE
Turn off 'react/jsx-pascal-case' lint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,7 @@
 
   "rules": {
     "no-tabs": "error",
+    "react/jsx-pascal-case": "off",
     "react/prop-types": 0,
     "no-unused-expressions": "off",
     "babel/no-unused-expressions": "warn"


### PR DESCRIPTION
This lint gets confused by theme-ui's `Styled.h1` and similar.