### PR TITLE
Fix studio.opencast.org default workflow

### DIFF
--- a/.deploy-settings.toml
+++ b/.deploy-settings.toml
@@ -1,0 +1,2 @@
+[upload]
+workflowId = 'fast'

--- a/.travis-deploy.sh
+++ b/.travis-deploy.sh
@@ -44,7 +44,7 @@ fi
 
 # Add new content
 mv "${srcpath}"/build/* .
-cp "${srcpath}"/deploy-settings.json settings.json
+cp "${srcpath}"/.deploy-settings.toml settings.toml
 if [ -n "${cname:-}" ]; then
   echo "${cname}" > CNAME
 fi

--- a/deploy-settings.json
+++ b/deploy-settings.json
@@ -1,5 +1,0 @@
-{
-  "upload": {
-    "workflowId": "fast"
-  }
-}


### PR DESCRIPTION
This patch fixes the configuration for studio.opencast.org which was
still trying to use a JSON configuration file.

This causes no configuration being loaded and studio.opencast.org
ingesting media with schedule-and-upload to develop.opencast.org by
default, causing regular service errors.