### PR TITLE
Fix too long filenames

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -73,8 +73,8 @@ export const mimeToExt = mime => {
 // `mime` can be null or a string and is converted to a file extension on a best
 // effort basis.
 export const recordingFileName = ({ mime, flavor, title, presenter }) => {
-  const titlePart = title ? ` - ${title}` : '';
-  const presenterPart = presenter ? ` - ${presenter}` : '';
+  const titlePart = (title ? ` - ${title}` : '').substring(0, 50);
+  const presenterPart = (presenter ? ` - ${presenter}` : '').substring(0, 50);
   return `${nowAsString()}${titlePart}${presenterPart} (${flavor}, OC Studio).${mimeToExt(mime)}`;
 };
 


### PR DESCRIPTION
If a title is extremely long (can easily happen if it is generated
based on some metadata) Studio may generate a filename which exceeds the
file systems maximum file length. This can cause problems when handling
or processing the file.

This patch sets an upper limit of 50 characters for title and presenter
each in the filename. This should suffice to identify the name while
avoiding potential problems.