### PR TITLE
Add GitHub-Action CI script to build and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,3 +13,34 @@ jobs:
     - run: npm ci
     - run: npm run build
     - run: npm test
+
+
+    # Prepare (test) deployment
+    - name: Determine public URL
+      id: public_url
+      run: |
+        if [[ "$GITHUB_REPOSITORY" == "elan-ev/opencast-studio" ]] && [ "$GITHUB_REF" == "refs/heads/production" ]; then
+          builddate="$(date --utc '+%Y%m%d%H%M%S')"
+          buildno="$(printf '%06d' "${{ github.run_id }}")"
+          deploydir="build-${builddate}-${GITHUB_REPOSITORY}-${buildno}-${srcbranch}"
+          deploydir="$(echo "${deploydir}" | sed 's/[^a-Z0-9]/-/g')"
+          echo "::set-output name=public_url::${deploydir}"
+        else
+          echo "::set-output name=public_url::"
+        fi
+
+    - name: Build for deployment
+      env:
+        REACT_APP_ENABLE_SENTRY: 1
+        REACT_APP_INCLUDE_LEGAL_NOTICES: 1
+        PUBLIC_URL: ${{ steps.public_url.outputs.public_url }}
+      run: npm run build
+
+    # Archive files to be used in the `deploy` workflow
+    - name: Archive deployment files as artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-deployment-files
+        path: |
+          build
+          .deploy-settings.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: Build & test
+
+on: [pull_request, push]
+
+jobs:
+  main:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '15'
+    - run: npm ci
+    - run: npm run build
+    - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,22 @@ jobs:
       id: public_url
       run: |
         if [[ "$GITHUB_REPOSITORY" == "elan-ev/opencast-studio" ]] && [ "$GITHUB_REF" == "refs/heads/production" ]; then
-          builddate="$(date --utc '+%Y%m%d%H%M%S')"
-          buildno="$(printf '%06d' "${{ github.run_id }}")"
-          deploydir="build-${builddate}-${GITHUB_REPOSITORY}-${buildno}-${srcbranch}"
-          deploydir="$(echo "${deploydir}" | sed 's/[^a-Z0-9]/-/g')"
-          echo "::set-output name=public_url::${deploydir}"
+          deploydir="/"
         else
-          echo "::set-output name=public_url::"
+          builddate="$(date --utc '+%Y-%m-%d_%H-%M-%S')"
+          buildno="$(printf '%06d' "${{ github.run_id }}")"
+          if [[ $GITHUB_REF == refs/pull/* ]]; then
+            tmp="${GITHUB_REF#refs/pull/}"
+            prnum="${tmp%/merge}"
+            deploydir="${builddate}-pr${prnum}-${buildno}"
+          else
+            branch="${GITHUB_REF#refs/heads/}"
+            deploydir="${builddate}-${{ github.repository_owner }}-${buildno}-${branch}"
+          fi
+          deploydir="/$(echo "${deploydir}" | LC_ALL=C sed -e 's/[^a-zA-Z0-9\-_]/-/g')"
         fi
+        echo "::set-output name=public_url::${deploydir}"
+        echo ${deploydir} > deploydir.tmp
 
     - name: Build for deployment
       env:
@@ -44,3 +52,4 @@ jobs:
         path: |
           build
           .deploy-settings.toml
+          deploydir.tmp

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,79 @@
+name: Deploy production
+
+on:
+  workflow_run:
+    workflows: ["Build & test"]
+    branches: [production]
+    types: [completed]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Prepare gh-pages branch
+      run: |
+        git fetch
+        if git checkout gh-pages; then
+          # Save CNAME and 404.html
+          tmpdir=$(mktemp)
+          cp CNAME 404.html $tmpdir || :
+
+          # Remove all previous files
+          git ls-files | while read -r f; do git rm -rf "$f"; done
+
+          # Restore 404.html and CNAME
+          cp $tmpdir/404.html $tmpdir/CNAME . || :
+        else
+          git checkout --orphan gh-pages
+          git ls-files | while read -r f; do rm -f "$f"; git rm --cached "$f"; done
+        fi
+
+    # Unfortunately we cannot use `actions/download-artifact` here since that
+    # only allows to download artifacts from the same run.
+    - name: Download artifacts from build workflow
+      uses: actions/github-script@v3.1.0
+      with:
+        script: |
+          const artifacts = await github.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }},
+          });
+          const deployFiles = artifacts.data.artifacts
+              .filter(a => a.name == "test-deployment-files")[0];
+          const download = await github.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: deployFiles.id,
+              archive_format: 'zip',
+          });
+
+          const fs = require('fs');
+          fs.writeFileSync('${{github.workspace}}/artifacts.zip', Buffer.from(download.data));
+
+          // The artifact is not needed anymore
+          github.actions.deleteArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: deployFiles.id,
+          })
+
+    - name: extract artifacts
+      run: unzip artifacts.zip
+
+    - name: Prepare deployment files
+      run: |
+        mv .deploy-settings.toml settings.toml
+        mv build/* .
+        rmdir build
+
+    - name: Commit and push
+      run: |
+        git add .
+        git config --global user.name 'GitHub Actions'
+        git config --global user.email 'noreply@github.com'
+        git commit -m "Deploy ${{ github.event.workflow_run.head_sha }} ($(date))"
+        git push origin gh-pages

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -1,0 +1,87 @@
+name: Test Deploy
+
+on:
+  workflow_run:
+    workflows: ["Build & test"]
+    branches-ignore: [production]
+    types: [completed]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    if: github.event.workflow_run.conclusion == 'success' && github.repository_owner == 'elan-ev'
+    steps:
+    - name: Prepare deploy key
+      run: |
+        mkdir ~/.ssh
+        chmod 700 ~/.ssh
+        echo "${{ secrets.STUDIO_TEST_DEPLOY_KEY }}" | base64 -d > ~/.ssh/id_rsa
+        chmod 600 ~/.ssh/id_rsa
+        ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+    # Unfortunately we cannot use `actions/download-artifact` here since that
+    # only allows to download artifacts from the same run.
+    - name: Download artifacts from build workflow
+      uses: actions/github-script@v3.1.0
+      with:
+        script: |
+          const artifacts = await github.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }},
+          });
+          const deployFiles = artifacts.data.artifacts
+              .filter(a => a.name == "test-deployment-files")[0];
+          const download = await github.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: deployFiles.id,
+              archive_format: 'zip',
+          });
+
+          const fs = require('fs');
+          fs.writeFileSync('${{github.workspace}}/artifacts.zip', Buffer.from(download.data));
+
+          // The artifact is not needed anymore
+          github.actions.deleteArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: deployFiles.id,
+          })
+
+    - name: extract artifacts
+      run: unzip artifacts.zip
+
+    - name: Checkout test deployment repo
+      run: |
+        rm -rf studio-test || :
+        git clone "git@github.com:elan-ev/studio-test.git"
+        cd studio-test
+        git checkout gh-pages
+
+    - name: Prepare deployment files
+      run: |
+        deploydir=$(cat deploydir.tmp)
+        mkdir studio-test/${deploydir}
+        mv .deploy-settings.toml studio-test/${deploydir}/settings.toml
+        rm build/static/js/*.map
+        mv build/* studio-test/${deploydir}/
+        rmdir build
+
+    - name: Build new index HTML
+      working-directory: studio-test
+      run: |
+        echo '<html><body><ul>' > index.html
+        find . -maxdepth 1 -name 'build*' -type d \
+          | sort -r \
+          | sed 's/^\(.*\)$/<li><a href=\1>\1<\/a><\/li>/' >> index.html
+        echo '</ul></body></html>' >> index.html
+
+    - name: Commit and push
+      working-directory: studio-test
+      run: |
+        git add .
+        git config --global user.name 'GitHub Actions'
+        git config --global user.email 'noreply@github.com'
+        git commit -m "Deploy ${{ github.event.workflow_run.head_sha }} ($(date))"
+        git push origin gh-pages


### PR DESCRIPTION
We wanted to switch to GH actions for a while now and now it's finally happening. 

The main structure is the same as in `elan-ev/tobira`. We use a `workflow_run` action that triggers once the main CI action is done. That `workflow_run` then has access to secrets and can deploy stuff. The build artifacts are transferred between the workflows via temporary artifacts.

Unlike with Tobira, here we don't even check which user started the action. That's because Studio is a static web app, meaning that no code (something attackers could modify) runs *on* any of our servers. As far as I can see it, this should be save.

This does not yet add a comment to PRs notifying about the deployment. That's straight forward but still a bit of extra work and I don't think it's really worth it, considering the development state of Studio.