### PR TITLE
Remove note about Opencast 8 differences in `CONFIGURATION.md`

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -1,7 +1,5 @@
 # Configuration
 
-> **Note**: this is the documentation on the `master` branch, targetting Opencast 9. If you are interested in documentation about the Studio version that shipped with the current stable Opencast 8, please see [the `opencast-8` branch](https://github.com/elan-ev/opencast-studio/blob/opencast-8/CONFIGURATION.md).
-
 Opencast Studio can be configured in three different ways:
 
 - the user can manually configure certain things on the settings page,


### PR DESCRIPTION
Very soon, OC8 won't be supported anymore. Thus we can remove this warning and the corresponding branch.