### PR TITLE
Do not hard-code hover color

### DIFF
--- a/src/ui/studio/audio-setup/index.js
+++ b/src/ui/studio/audio-setup/index.js
@@ -229,7 +229,7 @@ const OptionButton = ({ children, icon, label, onClick }) => {
         p: 2,
         '&:hover': {
           boxShadow: theme => `0 0 10px ${theme.colors.gray[2]}`,
-          backgroundColor: 'white',
+          filter: 'brightness(1.2)',
         },
       }}
     >

--- a/src/ui/studio/video-setup/index.js
+++ b/src/ui/studio/video-setup/index.js
@@ -258,7 +258,7 @@ const OptionButton = ({ icon, label, onClick, disabledText = false }) => {
         p: 2,
         '&:hover': disabled ? {} : {
           boxShadow: theme => `0 0 10px ${theme.colors.gray[2]}`,
-          backgroundColor: 'white',
+          filter: 'brightness(1.2)',
         },
       }}
     >


### PR DESCRIPTION
Pull request #902 allows users to specify color themes for Studio. The
background of the main input selection buttons when hovering over them
is unfortunately hard-coded to pure white though, making a dark theme
basically impossible to specify.

This patch sets the background color dynamically based on the main color
instead by just slightly brightening the color. The default looks
basically the same and specifying dark themes is now a lot easier

https://user-images.githubusercontent.com/1008395/159597503-2b3a6489-122a-49e5-9c95-8d1849088fec.mp4

.