### PR TITLE
Fix master deployment by not removing build artifacts

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -54,13 +54,6 @@ jobs:
           const fs = require('fs');
           fs.writeFileSync('${{github.workspace}}/artifacts.zip', Buffer.from(download.data));
 
-          // The artifact is not needed anymore
-          github.actions.deleteArtifact({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              artifact_id: deployFiles.id,
-          })
-
     - name: extract artifacts
       run: unzip artifacts.zip
 

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -3,7 +3,6 @@ name: Test Deploy
 on:
   workflow_run:
     workflows: ["Build & test"]
-    branches-ignore: [production]
     types: [completed]
 
 jobs:
@@ -41,13 +40,6 @@ jobs:
 
           const fs = require('fs');
           fs.writeFileSync('${{github.workspace}}/artifacts.zip', Buffer.from(download.data));
-
-          // The artifact is not needed anymore
-          github.actions.deleteArtifact({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              artifact_id: deployFiles.id,
-          })
 
     - name: extract artifacts
       run: unzip artifacts.zip


### PR DESCRIPTION
The problem is, that we want the test deployment and the
production deployment for `master`. But both workflows delete
the build artifacts after downloading them. So only one gets it,
the other one fails.
This is solved by just not deleting build artifacts.

The build artifacts for Studio are very small (1.4MB) or so, so
even with lots of parallel builds, it's unlikely we will reach
GitHub's limit.