### PR TITLE
Switch from single-quote in JSX to double-quotes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,7 @@
     "eol-last": ["error", "always"],
     "func-call-spacing": ["error", "never"],
     "indent": ["error", 2, { "SwitchCase": 1, "MemberExpression": "off" }],
-    "jsx-quotes": ["error", "prefer-single"],
+    "jsx-quotes": ["error", "prefer-double"],
     "linebreak-style": ["error", "unix"],
     "max-len": ["error", { "code": 120, "ignoreUrls": true }],
     "no-multi-spaces": ["warn", { "ignoreEOLComments": true }],

--- a/src/App.js
+++ b/src/App.js
@@ -44,15 +44,15 @@ const Routes = ({ settingsManager, userHasWebcam }) => {
     <Fragment>
       <PreventClose />
       <Switch>
-        <Route path='/settings' exact>
+        <Route path="/settings" exact>
           <SettingsPage settingsManager={settingsManager} />
         </Route>
 
-        <Route path='/about' exact>
+        <Route path="/about" exact>
           <About />
         </Route>
 
-        <Route path='/' exact>
+        <Route path="/" exact>
           <Studio
             activeStep={activeStep}
             updateActiveStep={updateActiveStep}
@@ -60,8 +60,8 @@ const Routes = ({ settingsManager, userHasWebcam }) => {
           />
         </Route>
 
-        <Route path='/*'>
-          <Redirect to={{ pathname: '/', search: location.search }} />
+        <Route path="/*">
+          <Redirect to={{ pathname: "/", search: location.search }} />
         </Route>
       </Switch>
     </Fragment>

--- a/src/ui/about.js
+++ b/src/ui/about.js
@@ -30,13 +30,13 @@ function LegalNotices() {
 
       <Themed.p>
         <FontAwesomeIcon icon={faGlobeEurope} />{' '}
-        <Themed.a href='https://elan-ev.de'>elan-ev.de</Themed.a>
+        <Themed.a href="https://elan-ev.de">elan-ev.de</Themed.a>
         <br />
         <FontAwesomeIcon icon={faEnvelope} />{' '}
-        <Themed.a href='mailto:kontakt@elan-ev.de'>kontakt@elan-ev.de</Themed.a>
+        <Themed.a href="mailto:kontakt@elan-ev.de">kontakt@elan-ev.de</Themed.a>
         <br />
         <FontAwesomeIcon icon={faPhone} />{' '}
-        <Themed.a href='tel:+4944199866610'>+49&thinsp;441 998&thinsp;666&thinsp;10</Themed.a>
+        <Themed.a href="tel:+4944199866610">+49&thinsp;441 998&thinsp;666&thinsp;10</Themed.a>
       </Themed.p>
 
       <Themed.p>
@@ -58,7 +58,7 @@ function About(props) {
           <Themed.h1>Opencast Studio</Themed.h1>
         </header>
         <Themed.p>
-          A web-based recording studio for <Themed.a href='https://opencast.org'>Opencast</Themed.a>.
+          A web-based recording studio for <Themed.a href="https://opencast.org">Opencast</Themed.a>.
         </Themed.p>
         <Themed.p>
           Opencast Studio allows you to record your camera, your display and your microphoneʼs audio.
@@ -67,11 +67,11 @@ function About(props) {
         </Themed.p>
         <Themed.p>
           This is free software under the terms of the{' '}
-          <Themed.a href='https://github.com/elan-ev/opencast-studio/blob/master/LICENSE'>
+          <Themed.a href="https://github.com/elan-ev/opencast-studio/blob/master/LICENSE">
             MIT License
           </Themed.a>{' '}
-          developed by the <Themed.a href='https://elan-ev.de'>ELAN e.V.</Themed.a> in cooperation
-          with the <Themed.a href='https://ethz.ch'>ETH Zürich</Themed.a>.
+          developed by the <Themed.a href="https://elan-ev.de">ELAN e.V.</Themed.a> in cooperation
+          with the <Themed.a href="https://ethz.ch">ETH Zürich</Themed.a>.
         </Themed.p>
 
         <Themed.h2>How it works</Themed.h2>
@@ -87,7 +87,7 @@ function About(props) {
             <Themed.p>
               If you are experiencing any difficulties or found any bugs,
               please take a look at the{' '}
-              <Themed.a href='https://github.com/elan-ev/opencast-studio/issues'>
+              <Themed.a href="https://github.com/elan-ev/opencast-studio/issues">
                 issue tracker on GitHub
               </Themed.a>.
               Before filing a new issue, please check if one about your topic already exists.
@@ -96,7 +96,7 @@ function About(props) {
             <Themed.p>
               If you are interested in additional development
               or want to support the development of Opencast Studio, please contact{' '}
-              <Themed.a href='mailto:opencast-support@elan-ev.de'>
+              <Themed.a href="mailto:opencast-support@elan-ev.de">
                 opencast-support@elan-ev.de
               </Themed.a>.
             </Themed.p>
@@ -109,19 +109,19 @@ function About(props) {
         </Themed.p>
         <ul>
           <li>
-            <Themed.a href='https://github.com/slampunk'>Duncan Smith</Themed.a> for starting this
+            <Themed.a href="https://github.com/slampunk">Duncan Smith</Themed.a> for starting this
             project
           </li>
           <li>
-            <Themed.a href='https://github.com/cilt-uct'>University of Cape Town (CILT)</Themed.a>
+            <Themed.a href="https://github.com/cilt-uct">University of Cape Town (CILT)</Themed.a>
             {' '}for letting Duncan start the project
           </li>
           <li>
-            <Themed.a href='https://ethz.ch'>ETH Zürich</Themed.a> for financial support and
+            <Themed.a href="https://ethz.ch">ETH Zürich</Themed.a> for financial support and
             testing
           </li>
           <li>
-            <Themed.a href='https://github.com/elan-ev'>ELAN e.V.</Themed.a> for the re-implementation
+            <Themed.a href="https://github.com/elan-ev">ELAN e.V.</Themed.a> for the re-implementation
             and the ongoing development
           </li>
           <li>
@@ -136,8 +136,8 @@ function About(props) {
           Build date {process.env.REACT_APP_BUILD_DATE || '?'},
           commit{' '}
           <Themed.a
-            aria-label='Git commit on GitHub'
-            href={'https://github.com/elan-ev/opencast-studio/commit/'
+            aria-label="Git commit on GitHub"
+            href={"https://github.com/elan-ev/opencast-studio/commit/"
                   + process.env.REACT_APP_GIT_SHA }
           >
             {process.env.REACT_APP_GIT_SHA || '?'}

--- a/src/ui/elements.js
+++ b/src/ui/elements.js
@@ -56,7 +56,7 @@ export const Input = ({
           <input
             aria-invalid={errors[name] ? 'true' : 'false'}
             aria-describedby={`${name}Error`}
-            autoComplete='off'
+            autoComplete="off"
             name={name}
             ref={register({
               validate,

--- a/src/ui/header.js
+++ b/src/ui/header.js
@@ -12,7 +12,7 @@ import {
   faWrench,
   faInfoCircle,
   faVideo,
-} from '@fortawesome/free-solid-svg-icons';
+} from "@fortawesome/free-solid-svg-icons";
 
 import { useStudioState } from '../studio-state';
 
@@ -77,12 +77,12 @@ const Brand = () => {
       }}>
       <picture sx={{ display: 'block', height: theme => theme.heights.headerHeight }}>
         <source
-          media='(min-width: 920px)'
+          media="(min-width: 920px)"
           srcSet={`${process.env.PUBLIC_URL}/opencast-studio.svg`}
         />
         <img
           src={`${process.env.PUBLIC_URL}/opencast-studio-small.svg`}
-          alt='Opencast Studio'
+          alt="Opencast Studio"
           sx={{ height: theme => theme.heights.headerHeight }}
         />
       </picture>
@@ -182,13 +182,13 @@ const Navigation = props => {
       <nav
         ref={n => {
           if (n) {
-            n.style.height = isOpened ? n.scrollHeight + 'px' : '';
+            n.style.height = isOpened ? n.scrollHeight + 'px' : "";
           }
         }}
         sx={{
           overflow: 'hidden',
           zIndex: 10,
-          // This '!important' is necessary unfortunately to override the inline
+          // This "!important" is necessary unfortunately to override the inline
           // style set in the `ref` attribute above. Otherwise opening the menu
           // in mobile view and switching to desktop view (e.g. by rotating
           // phone) would result in a very strange artifact.
@@ -202,21 +202,21 @@ const Navigation = props => {
         }}
       >
         <NavElement
-          target='/'
+          target="/"
           icon={faVideo}
           onClick={closeMenu}
         >
           {t('nav-recording')}
         </NavElement>
         <NavElement
-          target='/settings'
+          target="/settings"
           icon={faWrench}
           onClick={closeMenu}
         >
           {t('nav-settings')}
         </NavElement>
         <NavElement
-          target='/about'
+          target="/about"
           icon={faInfoCircle}
           onClick={closeMenu}
         >

--- a/src/ui/settings/language.js
+++ b/src/ui/settings/language.js
@@ -18,13 +18,13 @@ const LanguageSettings = () => {
   return (
     <SettingsSection title={t('settings-general-header')}>
       <label
-        htmlFor='studio-lang'
+        htmlFor="studio-lang"
         sx={{ variant: 'styles.label' }}
       >
         {lang_label}
       </label>
       <select
-        id='studio-lang'
+        id="studio-lang"
         sx={{ variant: 'styles.select' }}
         defaultValue={i18n.language}
         onChange={e => i18n.changeLanguage(e.target.value)}

--- a/src/ui/settings/opencast.js
+++ b/src/ui/settings/opencast.js
@@ -4,7 +4,7 @@ import { jsx } from 'theme-ui';
 
 import { useTranslation } from 'react-i18next';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCheckCircle, faCircleNotch, faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
+import { faCheckCircle, faCircleNotch, faExclamationCircle } from "@fortawesome/free-solid-svg-icons";
 import useForm from 'react-hook-form';
 import { Link, useLocation } from 'react-router-dom';
 import { Box, Button } from '@theme-ui/components';
@@ -81,7 +81,7 @@ function OpencastSettings({ settingsManager }) {
       case STATE_CONNECTED:    // <- login data is provided in some way -> state impossible
       case STATE_UNCONFIGURED: // <- server URL is required -> state impossible
       default:
-        console.error('bug: invalid state reached...');
+        console.error("bug: invalid state reached...");
         setStatus('error');
         setError('internal error :(');
     }
@@ -113,7 +113,7 @@ function OpencastSettings({ settingsManager }) {
           { showServerUrl && <Input
             errors={errors}
             label={t('upload-settings-label-server-url')}
-            name='serverUrl'
+            name="serverUrl"
             register={register}
             validate={value => {
               try {
@@ -123,7 +123,7 @@ function OpencastSettings({ settingsManager }) {
               } catch (e) {
                 let err = t('upload-settings-invalid-url');
                 if (!value.startsWith('https://') && !value.startsWith('http://')) {
-                  err += ' ' + t('upload-settings-invalid-url-http-start');
+                  err += " " + t('upload-settings-invalid-url-http-start');
                 }
                 return err;
               }
@@ -134,7 +134,7 @@ function OpencastSettings({ settingsManager }) {
           { showUsername && <Input
             errors={errors}
             label={t('upload-settings-label-username')}
-            name='loginName'
+            name="loginName"
             register={register}
             required
           /> }
@@ -142,10 +142,10 @@ function OpencastSettings({ settingsManager }) {
           { showPassword && <Input
             errors={errors}
             label={t('upload-settings-label-password')}
-            name='loginPassword'
+            name="loginPassword"
             register={register}
             required
-            type='password'
+            type="password"
           /> }
 
           <footer sx={{ mt: 4 }}>
@@ -159,7 +159,7 @@ function OpencastSettings({ settingsManager }) {
             /> }
             { hasRecording && status === 'saved' && (
               <Link
-                to={{ pathname: '/', search: location.search }}
+                to={{ pathname: "/", search: location.search }}
                 sx={{ ml: 3, variant: 'styles.a' }}
               >
                 {t('settings-back-to-recording')}

--- a/src/ui/studio/audio-setup/index.js
+++ b/src/ui/studio/audio-setup/index.js
@@ -66,7 +66,7 @@ export default function AudioSetup(props) {
   return <StepContainer>{ body }</StepContainer>;
 }
 
-// The two large option buttons for 'no audio' and 'Microphone'.
+// The two large option buttons for "no audio" and "Microphone".
 const SourceSelection = ({ selectNoAudio, selectMicrophone, backToVideoSetup }) => {
   const { t } = useTranslation();
 
@@ -149,7 +149,7 @@ const MicrophonePreview = ({ reselectSource, enterStudio }) => {
         minWidth: '285px',
         'align-items': 'center'
       }}>
-        <label htmlFor='sources-audio-device'
+        <label htmlFor="sources-audio-device"
           sx={{
             mr: 3,
             display: 'flex',
@@ -157,14 +157,14 @@ const MicrophonePreview = ({ reselectSource, enterStudio }) => {
             alignItems: 'center',
           }}>{ t('sources-audio-device') }:</label>
         <select
-          id='sources-audio-device'
+          id="sources-audio-device"
           sx={{ variant: 'styles.select', flex: '1 0 0', minWidth: 0 }}
           value={currentDeviceId}
           onChange={e => changeDevice(e.target.value)}
         >
           {
             devices.map((d, i) => (
-              <option key={i} value={d.deviceId}>{ d.label || 'unlabeled microphone' }</option>
+              <option key={i} value={d.deviceId}>{ d.label || "unlabeled microphone" }</option>
             ))
           }
         </select>
@@ -172,25 +172,25 @@ const MicrophonePreview = ({ reselectSource, enterStudio }) => {
     </Fragment>;
   } else if (audioAllowed === false) {
     body = <Fragment>
-      <FontAwesomeIcon icon={faExclamationTriangle} size='3x' />
-      <Spacer min='16px' max='48px' />
+      <FontAwesomeIcon icon={faExclamationTriangle} size="3x" />
+      <Spacer min="16px" max="48px" />
       <Notification isDanger>
-        <Heading as='h3' mb={2}>
+        <Heading as="h3" mb={2}>
           {t('source-audio-not-allowed-title')}
         </Heading>
-        <Text variant='text'>{t('source-audio-not-allowed-text')}</Text>
+        <Text variant="text">{t('source-audio-not-allowed-text')}</Text>
       </Notification>
     </Fragment>;
   } else if (audioUnexpectedEnd === true) {
     body = <Fragment>
-      <FontAwesomeIcon icon={faExclamationTriangle} size='3x' />
-      <Spacer min='16px' max='48px' />
+      <FontAwesomeIcon icon={faExclamationTriangle} size="3x" />
+      <Spacer min="16px" max="48px" />
       <Notification isDanger>
-        <Text variant='text'>{t('error-lost-audio-stream')}</Text>
+        <Text variant="text">{t('error-lost-audio-stream')}</Text>
       </Notification>
     </Fragment>;
   } else {
-    body = <Spinner size='75'/>;
+    body = <Spinner size="75"/>;
   }
 
   return (
@@ -236,7 +236,7 @@ const OptionButton = ({ children, icon, label, onClick }) => {
       }}
     >
       <div sx={{ display: 'block', textAlign: 'center', mb: 3 }}>
-        <FontAwesomeIcon icon={icon} size='3x'/>
+        <FontAwesomeIcon icon={icon} size="3x"/>
       </div>
       <div sx={{ fontSize: 4 }}>{label}</div>
       {children}

--- a/src/ui/studio/audio-setup/preview-audio.js
+++ b/src/ui/studio/audio-setup/preview-audio.js
@@ -28,8 +28,8 @@ export default function PreviewAudio({ stream }) {
   return (
     <canvas
       ref={canvasRef}
-      width='800px'
-      height='200px'
+      width="800px"
+      height="200px"
       sx={{
         width: '100%',
         maxHeight: '200px',

--- a/src/ui/studio/recording/media-devices.js
+++ b/src/ui/studio/recording/media-devices.js
@@ -66,7 +66,7 @@ function MediaDevice({ title, stream, paused }) {
         justifyContent: 'center',
         alignItems: 'center',
       }}>
-        <FontAwesomeIcon icon={faExclamationTriangle} size='3x' />
+        <FontAwesomeIcon icon={faExclamationTriangle} size="3x" />
       </div>
     );
   }

--- a/src/ui/studio/recording/recording-buttons.js
+++ b/src/ui/studio/recording/recording-buttons.js
@@ -44,7 +44,7 @@ export const PauseButton = props => (
       },
     }}
   >
-    <span className='fa-layers'>
+    <span className="fa-layers">
       <FontAwesomeIcon icon={faPauseCircle} sx={{ color: 'button_bg' }} />
     </span>
   </Button>
@@ -68,9 +68,9 @@ export const RecordButton = props => (
       },
     }}
   >
-    <span className='fa-layers record-buttons'>
+    <span className="fa-layers record-buttons">
       <FontAwesomeIcon icon={props.countdown ? faCircleNotch : faCircle} spin={props.countdown} />
-      <FontAwesomeIcon icon={faCircle} transform='shrink-6' />
+      <FontAwesomeIcon icon={faCircle} transform="shrink-6" />
     </span>
   </Button>
 );
@@ -85,7 +85,7 @@ export const ResumeButton = props => (
       },
     }}
   >
-    <span className='fa-layers'>
+    <span className="fa-layers">
       <FontAwesomeIcon icon={faPlayCircle} sx={{ color: 'button_bg' }} />
     </span>
   </Button>

--- a/src/ui/studio/recording/recording-controls.js
+++ b/src/ui/studio/recording/recording-controls.js
@@ -5,7 +5,7 @@ import { jsx } from 'theme-ui';
 import { useEffect, useRef } from 'react';
 import { Beforeunload } from 'react-beforeunload';
 import { useTranslation } from 'react-i18next';
-import { useHistory } from 'react-router';
+import { useHistory } from "react-router";
 
 import Recorder from '../../../recorder';
 import { useSettings } from '../../../settings';
@@ -110,7 +110,7 @@ export default function RecordingControls({
     }
 
     history.listen(() => {
-      // This only happens when the user uses 'back' or 'forward' in their
+      // This only happens when the user uses "back" or "forward" in their
       // browser and they confirm they want to discard the recording.
       if (recordingState !== 'STATE_INACTIVE') {
         dispatch({ type: 'STOP_RECORDING' });
@@ -151,7 +151,7 @@ export default function RecordingControls({
         <Beforeunload onBeforeunload={event => event.preventDefault()} />
       )}
 
-      <div className='buttons' sx={{ display: 'flex', alignItems: 'center' }}>
+      <div className="buttons" sx={{ display: 'flex', alignItems: 'center' }}>
         {recordingState !== STATE_INACTIVE && <div sx={{ flex: 1, textAlign: 'right' }}>
           {recordingState === STATE_RECORDING && (
             <Tooltip content={t('pause-button-title')} offset={[0, 50]}>
@@ -172,7 +172,7 @@ export default function RecordingControls({
           )}
         </div>}
 
-        <div className='center'>
+        <div className="center">
           {recordingState === STATE_INACTIVE ? (
             <Tooltip content={t('record-button-title')} offset={[0, 50]}>
               <RecordButton

--- a/src/ui/studio/review/index.js
+++ b/src/ui/studio/review/index.js
@@ -235,7 +235,7 @@ const VideoControls = ({ currentTime, previewController }) => {
       }}
     >
       {settings.review?.disableCutting || <CutControls
-        marker='start'
+        marker="start"
         value={start}
         control={end}
         invariant={(start, end) => start < end}
@@ -262,7 +262,7 @@ const VideoControls = ({ currentTime, previewController }) => {
         </button>
       </Tooltip>
       {settings.review?.disableCutting || <CutControls
-        marker='end'
+        marker="end"
         value={end}
         control={start}
         invariant={(end, start) => start < end}
@@ -282,7 +282,7 @@ const CutControls = (
     <div sx={{ flex: 1, textAlign: marker === 'start' ? 'right' : 'left', color: 'gray.0' }}>
       { value !== null && <Fragment>
         <Trans { ...{ t } } i18nKey={`review-${marker}`}>
-          {{ [marker]: value }} <Link href='' onClick={event => {
+          {{ [marker]: value }} <Link href="" onClick={event => {
             event.preventDefault();
             previewController.current.currentTime = value;
           }} />
@@ -382,7 +382,7 @@ const Preview = forwardRef(function _Preview({ onTimeUpdate, onReady }, ref) {
       return v && v.currentTime > 0 && !v.paused && !v.ended;
     },
     get isReadyToPlay() {
-      // State 2 means 'at least enough data to play one frame'
+      // State 2 means "at least enough data to play one frame"
       return allVideos.every(r => r.current.readyState >= 2);
     },
     play() {
@@ -518,7 +518,7 @@ const Preview = forwardRef(function _Preview({ onTimeUpdate, onReady }, ref) {
               }
             }} // eslint-disable-line
           }
-          preload='auto' tabIndex={'-1'}
+          preload="auto" tabIndex={'-1'}
           sx={{
             width: '100%',
             height: '100%',

--- a/src/ui/studio/save-creation/index.js
+++ b/src/ui/studio/save-creation/index.js
@@ -270,7 +270,7 @@ const PostAction = ({ goToFirstStep }) => {
 
       returnAction = (
         <Button
-          as='a'
+          as="a"
           title={label}
           href={settings.return.target}
           sx={{ whiteSpace: 'nowrap', fontWeight: 400, mb: 2 }}
@@ -356,11 +356,11 @@ const ConnectionUnconfiguredWarning = () => {
   const [colorMode] = useColorMode();
 
   return (
-    <Notification key='opencast-connection' isDanger>
-      <Trans i18nKey='warning-missing-connection-settings'>
+    <Notification key="opencast-connection" isDanger>
+      <Trans i18nKey="warning-missing-connection-settings">
         Warning.
         <Link
-          to={{ pathname: '/settings', search: location.search }}
+          to={{ pathname: "/settings", search: location.search }}
           sx={{ variant: 'styles.a', color: colorMode === 'dark' ? 'rgba(255, 255, 34, 0.8)' : '#ff2' }}
         >
           settings
@@ -410,7 +410,7 @@ const UploadForm = ({ uploadState, handleUpload }) => {
   const buttonLabel = !opencast.prettyServerUrl()
     ? t('save-creation-button-upload')
     : (
-      <Trans i18nKey='save-creation-upload-to'>
+      <Trans i18nKey="save-creation-upload-to">
         Upload to <code sx={{
           backgroundColor: 'rgba(0, 0, 0, 0.1)',
           borderRadius: '5px',
@@ -425,21 +425,21 @@ const UploadForm = ({ uploadState, handleUpload }) => {
 
       <form>
         { titleField !== FORM_FIELD_HIDDEN && <Input
-          name='title'
+          name="title"
           label={t('save-creation-label-title')}
           required={titleField === FORM_FIELD_REQUIRED}
           onChange={handleInputChange}
-          autoComplete='off'
+          autoComplete="off"
           defaultValue={title}
           {...{ errors, register }}
         /> }
 
         { presenterField !== FORM_FIELD_HIDDEN && <Input
-          name='presenter'
+          name="presenter"
           label={t('save-creation-label-presenter')}
           required={presenterField === FORM_FIELD_REQUIRED}
           onChange={handleInputChange}
-          autoComplete='off'
+          autoComplete="off"
           defaultValue={presenterValue}
           {...{ errors, register }}
         /> }
@@ -500,11 +500,11 @@ const NotConnectedWarning = () => {
       if (opencast.isLoginProvided()) {
         const referrer = document.referrer;
         problem = (
-          <Trans i18nKey='save-creation-warn-session-expired'>
+          <Trans i18nKey="save-creation-warn-session-expired">
             Foo
             {
               (referrer && !referrer.includes(window.origin || ''))
-                ? <Themed.a href={referrer} target='_blank' sx={{ color: '#ff2' }}>bar</Themed.a>
+                ? <Themed.a href={referrer} target="_blank" sx={{ color: '#ff2' }}>bar</Themed.a>
                 : <Fragment>bar</Fragment>
             }
             baz
@@ -514,10 +514,10 @@ const NotConnectedWarning = () => {
         onceResolved = t('save-creation-warn-once-refreshed');
       } else {
         problem = (
-          <Trans i18nKey='save-creation-warn-login-failed'>
+          <Trans i18nKey="save-creation-warn-login-failed">
             Failed.
             <Link
-              to={{ pathname: '/settings', search: location.search }}
+              to={{ pathname: "/settings", search: location.search }}
               sx={{ variant: 'styles.a', color: '#ff2' }}
             >
               settings
@@ -540,7 +540,7 @@ const NotConnectedWarning = () => {
     <Notification isDanger>
       <div sx={{ textAlign: 'center', fontSize: '40px', lineHeight: 1.3 }}>
         { retrying
-          ? <Spinner size='40' />
+          ? <Spinner size="40" />
           : <FontAwesomeIcon icon={faExclamationTriangle} />
         }
       </div>
@@ -590,18 +590,18 @@ const UploadProgress = ({ currentProgress, secondsLeft }) => {
   return (
     <Fragment>
       <div sx={{ display: 'flex', mb: 2 }}>
-        <Text variant='text'>{roundedPercent}%</Text>
+        <Text variant="text">{roundedPercent}%</Text>
         <div sx={{ flex: 1 }} />
-        <Text variant='text'>
-          {prettyTime && <Trans i18nKey='upload-time-left'>
+        <Text variant="text">
+          {prettyTime && <Trans i18nKey="upload-time-left">
             {{ time: prettyTime }} left
           </Trans>}
         </Text>
       </div>
-      <Progress max={1} value={currentProgress} variant='styles.progress'>
+      <Progress max={1} value={currentProgress} variant="styles.progress">
         { roundedPercent }
       </Progress>
-      <Text variant='text' sx={{ textAlign: 'center', mt: 2 }}>{t('upload-notification')}</Text>
+      <Text variant="text" sx={{ textAlign: 'center', mt: 2 }}>{t('upload-notification')}</Text>
     </Fragment>
   );
 };
@@ -619,9 +619,9 @@ const UploadSuccess = () => {
         height: '130px',
         color: 'primary',
       }}>
-        <FontAwesomeIcon icon={faCheckCircle} size='4x' />
+        <FontAwesomeIcon icon={faCheckCircle} size="4x" />
       </div>
-      <Text variant='text' sx={{ textAlign: 'center' }}>{t('message-upload-complete')}</Text>
+      <Text variant="text" sx={{ textAlign: 'center' }}>{t('message-upload-complete')}</Text>
       <Text sx={{ textAlign: 'center', mt: 2 }}>{t('message-upload-complete-explanation')}</Text>
     </Fragment>
   );

--- a/src/ui/studio/save-creation/recording-preview.js
+++ b/src/ui/studio/save-creation/recording-preview.js
@@ -24,7 +24,7 @@ const RecordingPreview = ({ onDownload, recording, title, presenter }) => {
   // Get file size in human readable format. We use base-1000 XB instead of
   // base-1024 XiB, as the latter would probably confuse some users and many
   // file managers use base-1000 anyway. Notably, the windows file manager
-  // calculates with base-1024 but shows 'XB'. So it is lying.
+  // calculates with base-1024 but shows "XB". So it is lying.
   const numBytes = blob.size;
   const round = n => {
     const digits = n < 10 ? 1 : 0;
@@ -65,7 +65,7 @@ const RecordingPreview = ({ onDownload, recording, title, presenter }) => {
           src={url}
           // Without this, some browsers show a black video element instead of the first frame.
           onLoadedData={e => e.target.currentTime = 0}
-          preload='auto'
+          preload="auto"
           sx={{
             maxWidth: '100%',
             height: '100%',
@@ -84,23 +84,23 @@ const RecordingPreview = ({ onDownload, recording, title, presenter }) => {
             color: 'primary',
             backgroundColor: 'rgba(0, 0, 0, 0.4)',
           }}>
-            <FontAwesomeIcon icon={faCheckCircle} size='4x' />
+            <FontAwesomeIcon icon={faCheckCircle} size="4x" />
           </div>
         )}
       </div>
       <Button
-        as='a'
-        role='button'
+        as="a"
+        role="button"
         sx={{
           width: '100%',
           maxWidth: '215px',
           margin: 'auto',
           mt: '10px',
         }}
-        target='_blank'
+        target="_blank"
         download={downloadName}
         href={url}
-        rel='noopener noreferrer'
+        rel="noopener noreferrer"
         onClick={onDownload}
       >
         <FontAwesomeIcon icon={faDownload} />

--- a/src/ui/studio/video-setup/index.js
+++ b/src/ui/studio/video-setup/index.js
@@ -52,23 +52,23 @@ export default function VideoSetup({ nextStep, userHasWebcam }) {
 
   // The warnings if we are not allowed to capture a stream.
   const userWarning = (state.userAllowed === false) && (
-    <Notification key='user-stream-warning' isDanger>
-      <Heading as='h3' mb={2}>
+    <Notification key="user-stream-warning" isDanger>
+      <Heading as="h3" mb={2}>
         {t('source-user-not-allowed-title')}
       </Heading>
       <Text>{t('source-user-not-allowed-text')}</Text>
     </Notification>
   );
   const displayWarning = (state.displayAllowed === false) && (
-    <Notification key='display-stream-warning' isDanger>
-      <Heading as='h3' mb={2}>
+    <Notification key="display-stream-warning" isDanger>
+      <Heading as="h3" mb={2}>
         {t('source-display-not-allowed-title')}
       </Heading>
       <Text>{t('source-display-not-allowed-text')}</Text>
     </Notification>
   );
   const unexpectedEndWarning = (state.userUnexpectedEnd || state.displayUnexpectedEnd) && (
-    <Notification key='unexpexted-stream-end-warning' isDanger>
+    <Notification key="unexpexted-stream-end-warning" isDanger>
       <Text>{t('error-lost-video-stream')}</Text>
     </Notification>
   );
@@ -261,7 +261,7 @@ const OptionButton = ({ icon, label, onClick, disabledText = false }) => {
       }}
     >
       <div sx={{ display: 'block', textAlign: 'center', mb: 3 }}>
-        <FontAwesomeIcon icon={icon} size='3x'/>
+        <FontAwesomeIcon icon={icon} size="3x"/>
       </div>
       <div sx={{ fontSize: 4 }}>{label}</div>
       <div sx={{ fontSize: 2, mt: 1 }}>{disabledText}</div>

--- a/src/ui/studio/video-setup/prefs.js
+++ b/src/ui/studio/video-setup/prefs.js
@@ -111,8 +111,8 @@ export const StreamSettings = ({ isDesktop, stream }) => {
   const [expandedHeight, setExpandedHeight] = useState(0);
   const { ref } = useResizeObserver({
     // We don't use the height passed to the callback as we want the outer
-    // height. We also add a magic '4' here. 2 pixels are for the border of the
-    // outer div. The other two are 'wiggle room'. If we always set the height
+    // height. We also add a magic "4" here. 2 pixels are for the border of the
+    // outer div. The other two are "wiggle room". If we always set the height
     // to fit exactly, this easily leads to unnessecary scrollbars appearing.
     // This in turn might lead to rewrapping and then a change in height, in
     // the worst case ending up in an infinite loop.
@@ -262,7 +262,7 @@ export const StreamSettings = ({ isDesktop, stream }) => {
               lineHeight: '20px',
               border: theme => `1px solid ${theme.colors.gray[2]}`,
             }}>
-              <Trans i18nKey='sources-video-preferences-note'>
+              <Trans i18nKey="sources-video-preferences-note">
                 <strong>Note:</strong> Explanation.
               </Trans>
             </div>
@@ -328,7 +328,7 @@ const UniveralSettings = ({ isDesktop, updatePrefs, prefs, stream, settings, isE
       <RadioButton
         isExpanded={isExpanded}
         id={`quality-auto-${kind}`}
-        value='auto'
+        value="auto"
         name={`quality-${kind}`}
         label={t('sources-video-quality-auto')}
         onChange={changeQuality}
@@ -365,7 +365,7 @@ const UserSettings = ({ updatePrefs, prefs, isExpanded }) => {
     const currentAr = width / height;
     const expectedAr = parseAspectRatio(prefs.aspectRatio);
 
-    // We have some range we accept as 'good'. You never know with these
+    // We have some range we accept as "good". You never know with these
     // floats...
     arState = (expectedAr * 0.97 < currentAr && currentAr < expectedAr / 0.97)
       ? 'ok'
@@ -377,11 +377,11 @@ const UserSettings = ({ updatePrefs, prefs, isExpanded }) => {
 
   return <Fragment>
     <PrefKey>
-      <label htmlFor='sources-video-device'>{t('sources-video-device')}:</label>
+      <label htmlFor="sources-video-device">{t('sources-video-device')}:</label>
     </PrefKey>
     <PrefValue>
       <select
-        id='sources-video-device'
+        id="sources-video-device"
         tabIndex={isExpanded ? '0' : '-1'}
         sx={{ variant: 'styles.select' }}
         value={currentDeviceId}
@@ -399,9 +399,9 @@ const UserSettings = ({ updatePrefs, prefs, isExpanded }) => {
     <PrefValue>
       <RadioButton
         isExpanded={isExpanded}
-        id='ar-auto'
-        value='auto'
-        name='aspectRatio'
+        id="ar-auto"
+        value="auto"
+        name="aspectRatio"
         label={t('sources-video-aspect-ratio-auto')}
         onChange={changeAspectRatio}
         checked={ASPECT_RATIOS.every(x => prefs.aspectRatio !== x)}
@@ -413,7 +413,7 @@ const UserSettings = ({ updatePrefs, prefs, isExpanded }) => {
             isExpanded={isExpanded}
             id={`ar-${ar}`}
             value={ar}
-            name='aspectRatio'
+            name="aspectRatio"
             onChange={changeAspectRatio}
             checked={prefs.aspectRatio === ar}
             state={arState}
@@ -429,7 +429,7 @@ const RadioButton = ({ id, value, checked, name, onChange, label, isExpanded }) 
 
   return <Fragment>
     <input
-      type='radio'
+      type="radio"
       onChange={e => onChange(e.target.value)}
       {...{ id, value, checked, name }}
       sx={{

--- a/src/ui/studio/video-setup/preview.js
+++ b/src/ui/studio/video-setup/preview.js
@@ -81,9 +81,9 @@ const PreviewVideo = ({ input }) => {
   if (!stream) {
     let inner;
     if (allowed === false || unexpectedEnd) {
-      inner = <FontAwesomeIcon icon={faExclamationTriangle} size='3x' />;
+      inner = <FontAwesomeIcon icon={faExclamationTriangle} size="3x" />;
     } else {
-      inner = <Spinner size='75'/>;
+      inner = <Spinner size="75"/>;
     }
 
     return (

--- a/src/ui/warnings.js
+++ b/src/ui/warnings.js
@@ -22,14 +22,14 @@ const Warnings = () => {
     window.location.hostname !== '127.0.0.1';
   if (usingUnsecureConnection) {
     warnings.push(
-      <Notification key='unsecure-connection' isDanger>{t('warning-https')}</Notification>
+      <Notification key="unsecure-connection" isDanger>{t('warning-https')}</Notification>
     );
   }
 
   // Warning about missing `MediaRecorder` support
   if (!isRecordingSupported()) {
     warnings.push(
-      <Notification key='media-recorder' isDanger>
+      <Notification key="media-recorder" isDanger>
         {t('warning-recorder-not-supported')}
         {onSafari() && ' ' + t('warning-recorder-safari-hint')}
       </Notification>


### PR DESCRIPTION
This is closer to normal HTML and is also the style used in other of our projects, e.g. Tobira and the editor.

I would have loved to amend the commit that introduced the single-quotes rule, but that has already been on master for some time. So we have to live with the somewhat noisy git history here.