### PR TITLE
Consistent Settings Style

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -143,6 +143,7 @@
   "video-settings-close": "Videoeinstellungen schließen",
   
   "settings-theme-appearance": "Aussehen",
+  "settings-theme-color": "Farbmodus",
   "settings-theme-dark": "Dunkles Design",
   "settings-theme-light": "Helles Design",
   "settings-theme-system": "System Design",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -144,10 +144,11 @@
   "video-settings-close": "Close video settings",
 
   "settings-theme-appearance": "Appearance",
+  "settings-theme-color": "Color mode",
   "settings-theme-dark": "Dark mode",
   "settings-theme-light": "Light mode",
   "settings-theme-system": "System design",
-  
+
   "nav-shortcuts": "Shortcuts",
   "record-shortcuts": "Recording",
   "edit-shortcuts": "Editing",

--- a/src/theme.js
+++ b/src/theme.js
@@ -240,6 +240,8 @@ const base = {
     },
     select: {
       backgroundColor: 'element_bg',
+      border: 'solid 1px var(--theme-ui-colors-gray-2)',
+      borderRadius: '2px',
       color: 'text',
       height: '2rem',
       fontSize: '14pt',

--- a/src/ui/elements.js
+++ b/src/ui/elements.js
@@ -38,8 +38,7 @@ export const Input = ({
         sx={{
           color: 'text',
           display: 'block',
-          fontSize: 2,
-          fontWeight: 'bold'
+          fontSize: 2
         }}
       >
         {label}

--- a/src/ui/settings/colorMode.js
+++ b/src/ui/settings/colorMode.js
@@ -48,7 +48,14 @@ const ColorModeSettings = () => {
 
   return (
     <SettingsSection title={t('settings-theme-appearance')}>
+      <label
+        htmlFor="studio-color"
+        sx={{ variant: 'styles.label' }}
+      >
+        {t('settings-theme-color')}
+      </label>
       <select
+        id="studio-color"
         sx={{ variant: 'styles.select' }}
         defaultValue={localStorage.getItem('theme')}
         onChange={themes => switchTheme(themes.target.value)}

--- a/src/ui/settings/elements.js
+++ b/src/ui/settings/elements.js
@@ -8,7 +8,7 @@ export const SettingsSection = ({ title, children }) => (
   <Box
     sx={{
       '&:not(:last-child)': {
-        mb: 5
+        mb: 4
       }
     }}
   >

--- a/src/ui/settings/opencast.js
+++ b/src/ui/settings/opencast.js
@@ -111,7 +111,7 @@ function OpencastSettings({ settingsManager }) {
   };
 
   return (
-    <GlobalHotKeys keyMap={otherShortcuts} handlers={handlers}>
+    <div sx={{ flex: '1 1 auto' }}><GlobalHotKeys keyMap={otherShortcuts} handlers={handlers}>
       <SettingsSection title={t('upload-settings-modal-header')}>
         <Box>
           { error && <Notification isDanger>{error}</Notification> }
@@ -176,7 +176,7 @@ function OpencastSettings({ settingsManager }) {
           </form>
         </Box>
       </SettingsSection>
-    </GlobalHotKeys>
+    </GlobalHotKeys></div>
   );
 }
 

--- a/src/ui/settings/page.js
+++ b/src/ui/settings/page.js
@@ -18,9 +18,13 @@ const SettingsPage = ({ settingsManager }) => {
       <header>
         <Themed.h1 sx={{ mb: '1.5em' }}>{t('settings-header')}</Themed.h1>
       </header>
-      <ColorModeSettings />
-      <LanguageSettings />
-      <OpencastSettings settingsManager={settingsManager} />
+      <div sx={{ display: 'flex', flexWrap: 'wrap', gap: '50px' }}>
+        <OpencastSettings settingsManager={settingsManager} />
+        <div sx={{ display: 'flex', flexDirection: 'column', flex: '1 1 auto' }}>
+          <ColorModeSettings />
+          <LanguageSettings />
+        </div>
+      </div>
     </Box>
   );
 };


### PR DESCRIPTION
This patch updates the settings style to make the different settings options use the same style. In particular, this means that:

- All input fields have labels
- Labels use the same font and are no longer sometimes bold
- Input element border color and radius are now identical

The last change will also effect some other views but a homogeneous style makes sense for the whole user interface anyway. It is just not so obvious on other pages.

This patch also puts the settings blocks in a flex-box so that we don't end up with extremely wide dropdowns with text only on the very left. In most cases you don't even need to scroll any longer.