### PR TITLE
Remove string 'adsfad' from shortcuts page

### DIFF
--- a/src/shortcuts/page.tsx
+++ b/src/shortcuts/page.tsx
@@ -138,7 +138,6 @@ const KeyboardShortcuts = () => {
       alignSelf: 'center',
       width: '100%',
     }}>
-    adsfad
       <h2 sx={{
         display: 'block',
         position: 'relative',


### PR DESCRIPTION
This minimal patch removes the string 'adsfad' from the shortcuts page.

![Bildschirmfoto vom 2023-04-04 07-25-02](https://user-images.githubusercontent.com/16731250/229695336-759b3ae6-da4f-4c73-82e6-eae87ef8bfca.png)
