### PR TITLE
Remove incorrect constant duration in DC catalog

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -260,7 +260,6 @@ By default, this template is used:
     <dcterms:title>{{ title }}</dcterms:title>
     {{ #presenter }}<dcterms:creator>{{ presenter }}</dcterms:creator>{{ /presenter }}
     {{ #seriesId }}<dcterms:isPartOf>{{ seriesId }}</dcterms:isPartOf>{{ /seriesId }}
-    <dcterms:extent xsi:type="dcterms:ISO8601">PT5.568S</dcterms:extent>
     <dcterms:spatial>Opencast Studio</dcterms:spatial>
 </dublincore>
 ```

--- a/src/opencast.tsx
+++ b/src/opencast.tsx
@@ -760,7 +760,6 @@ const DEFAULT_DCC_TEMPLATE = `<?xml version="1.0" encoding="UTF-8"?>
     <dcterms:title>{{ title }}</dcterms:title>
     {{ #presenter }}<dcterms:creator>{{ presenter }}</dcterms:creator>{{ /presenter }}
     {{ #seriesId }}<dcterms:isPartOf>{{ seriesId }}</dcterms:isPartOf>{{ /seriesId }}
-    <dcterms:extent xsi:type="dcterms:ISO8601">PT5.568S</dcterms:extent>
     <dcterms:spatial>Opencast Studio</dcterms:spatial>
 </dublincore>
 `;


### PR DESCRIPTION
This was here since the initial commit 👌 For one, having a fixed value doesn't make sense. But also, Opencast apparently doesn't care about `dcterms:extent`, but uses `dcterms:temporal xsi:type="dcterms:Period"` for durations. And it's not trivial for Studio to get the correct location anyway, so let's just throw it out.