### PR TITLE
Include recording start & end time in `dcterms:Period` metadata

### DIFF
--- a/src/steps/finish/upload.tsx
+++ b/src/steps/finish/upload.tsx
@@ -22,7 +22,7 @@ export const UploadBox: React.FC = () => {
   const settings = useSettings();
   const { t } = useTranslation();
   const opencast = useOpencast();
-  const { recordings, upload: uploadState, title, presenter, start, end } = useStudioState();
+  const { recordings, upload: uploadState, title, presenter, ...state } = useStudioState();
   const dispatch = useDispatch();
 
   function onProgress(progress: number) {
@@ -108,10 +108,12 @@ export const UploadBox: React.FC = () => {
       recordings: recordings.filter(Boolean),
       title,
       presenter,
-      start,
-      end,
       uploadSettings: settings.upload,
       onProgress,
+      start: state.start,
+      end: state.end,
+      startTime: state.recordingStartTime ?? unreachable("no start time set"),
+      endTime: state.recordingEndTime ?? unreachable("no end time set"),
     });
     progressHistory = [];
 

--- a/src/studio-state.tsx
+++ b/src/studio-state.tsx
@@ -50,6 +50,9 @@ export type StudioState = {
   start: null | number;
   end: null | number;
 
+  recordingStartTime: null | Date;
+  recordingEndTime: null | Date;
+
   upload: {
     error: null | string;
     state: UploadState;
@@ -89,6 +92,9 @@ const initialState = (hasWebcam: boolean): StudioState => ({
 
   start: null,
   end: null,
+
+  recordingStartTime: null,
+  recordingEndTime: null,
 
   upload: {
     error: null,
@@ -171,10 +177,15 @@ const reducer = (state: StudioState, action: ReducerAction): StudioState => {
     case "USER_UNEXPETED_END":
       return { ...state, userStream: null, userUnexpectedEnd: true };
 
-    case "START_RECORDING": return { ...state, isRecording: true };
-    case "STOP_RECORDING": return { ...state, isRecording: false };
+    case "START_RECORDING": return { ...state, isRecording: true, recordingStartTime: new Date() };
+    case "STOP_RECORDING": return { ...state, isRecording: false, recordingEndTime: new Date() };
     case "STOP_RECORDING_PREMATURELY":
-      return { ...state, isRecording: false, prematureRecordingEnd: true };
+      return {
+        ...state,
+        isRecording: false,
+        prematureRecordingEnd: true,
+        recordingEndTime: new Date(),
+      };
     case "CLEAR_RECORDINGS":
       return { ...state, recordings: [], prematureRecordingEnd: false };
     case "ADD_RECORDING":


### PR DESCRIPTION
Replaces #1048 which had some problems and needed to be rebased on top of the redesign anyway. I simply did this myself now.

Fixes https://github.com/elan-ev/opencast-studio/issues/738

This uses the correct start and end time of the recording. That means that if the recording was paused or cut, the video duration is not equal to `end - start`. But I think that's fine.