### PR TITLE
Record Desktop Audio

### DIFF
--- a/src/capturer.tsx
+++ b/src/capturer.tsx
@@ -55,7 +55,7 @@ export async function startDisplayCapture(
       ...videoConstraints,
       ...height,
     },
-    audio: false,
+    audio: true,
   };
 
   try {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -55,7 +55,9 @@
       "aspect-ratio-auto": "auto",
       "quality": "Qualität",
       "quality-auto": "auto",
-      "preferences-note": "<0>Hinweis:</0> Dies sind lediglich Präferenzen. Es ist nicht garantiert, dass alle Einstellungen von Ihrem Gerät unterstützt werden. Im Zweifelsfall 'auto' wählen."
+      "preferences-note": "<0>Hinweis:</0> Dies sind lediglich Präferenzen. Es ist nicht garantiert, dass alle Einstellungen von Ihrem Gerät unterstützt werden. Im Zweifelsfall 'auto' wählen.",
+      "display-audio-shared": "Bildschirmton wird aufgezeichnet.",
+      "display-audio-not-shared": "Bildschirmton wird nicht aufgezeichnet. <0>Hinweis</0>: Nicht alle Browser und Betriebssysteme unterstützen die Aufnahme des Bildschirmtons."
     },
     "audio": {
       "label": "Audioquelle auswählen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -12,9 +12,6 @@
   "warning-recorder-not-supported": "Your browser does not support recording media streams.",
   "warning-recorder-safari-hint": "If you are using Safari, you can enable the experimental feature 'MediaRecorder' in settings. However, on macOS, we recommend switching to Chrome or Firefox.",
 
-  "desktop-audio-info": "Desktop audio is recorded",
-  "no-desktop-audio-info": "Desktop audio is not recorded. \n If you want to record desktop audio, please use one of the following browsers: \n - Google Chrome, Edge and Opera: On Windows, the entire system audio can be captured, but on Linux and macOS only the audio of a tab can be captured. \n - Firefox, Safari and Internet Explorer do not support recording desktop audio.",
-
   "header": {
     "info": {
       "label": "Info"
@@ -58,7 +55,9 @@
       "aspect-ratio-auto": "auto",
       "quality": "Quality",
       "quality-auto": "auto",
-      "preferences-note": "<0>Note:</0> these are merely preferences and it cannot be guaranteed that all options are actually supported on your device. If in doubt, choose 'auto'."
+      "preferences-note": "<0>Note:</0> these are merely preferences and it cannot be guaranteed that all options are actually supported on your device. If in doubt, choose 'auto'.",
+      "display-audio-shared": "Display audio will be recorded.",
+      "display-audio-not-shared": "Display audio will not be recorded. <0>Note</0>: Not all browsers and operating systems support display audio capture."
     },
     "audio": {
       "label": "Select audio source",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -12,6 +12,9 @@
   "warning-recorder-not-supported": "Your browser does not support recording media streams.",
   "warning-recorder-safari-hint": "If you are using Safari, you can enable the experimental feature 'MediaRecorder' in settings. However, on macOS, we recommend switching to Chrome or Firefox.",
 
+  "desktop-audio-info": "Desktop audio is recorded",
+  "no-desktop-audio-info": "Desktop audio is not recorded. \n If you want to record desktop audio, please use one of the following browsers: \n - Google Chrome, Edge and Opera: On Windows, the entire system audio can be captured, but on Linux and macOS only the audio of a tab can be captured. \n - Firefox, Safari and Internet Explorer do not support recording desktop audio.",
+
   "header": {
     "info": {
       "label": "Info"

--- a/src/steps/recording/index.tsx
+++ b/src/steps/recording/index.tsx
@@ -92,7 +92,7 @@ export const Recording: React.FC<StepProps> = ({ goToNextStep, goToPrevStep }) =
     // sure, in case of a bug elsewhere, we clear the recordings here.
     dispatch({ type: "CLEAR_RECORDINGS" });
 
-    if (displayStream && userStream){
+    if (displayStream && userStream) {
       const onStopDesktop = addRecordOnStop(dispatch, "desktop");
       const onStopCamera = addRecordOnStop(dispatch, "video");
       const desktopStream = mixAudioIntoBothVideos(state.audioStream, displayStream);
@@ -102,16 +102,12 @@ export const Recording: React.FC<StepProps> = ({ goToNextStep, goToPrevStep }) =
       desktopRecorder.current.start();
       videoRecorder.current = new Recorder(cameraStream, settings.recording, onStopCamera);
       videoRecorder.current.start();
-    }
-
-    else if (displayStream) {
+    } else if (displayStream) {
       const onStop = addRecordOnStop(dispatch, "desktop");
       const stream = mixAudioIntoVideo(state.audioStream, displayStream);
       desktopRecorder.current = new Recorder(stream, settings.recording, onStop);
       desktopRecorder.current.start();
-    }
-
-    else if (userStream) {
+    } else if (userStream) {
       const onStop = addRecordOnStop(dispatch, "video");
       const stream = mixAudioIntoVideo(state.audioStream, userStream);
       videoRecorder.current = new Recorder(stream, settings.recording, onStop);

--- a/src/steps/video-setup/prefs.tsx
+++ b/src/steps/video-setup/prefs.tsx
@@ -6,7 +6,7 @@ import {
   Floating, FloatingContainer, FloatingHandle, FloatingTrigger, ProtoButton,
   WithTooltip, screenWidthAtMost, useColorScheme,
 } from "@opencast/appkit";
-import { FiSettings, FiX, FiInfo, FiVolumeX, FiVolume2 } from "react-icons/fi";
+import { FiSettings, FiX } from "react-icons/fi";
 
 import { Settings, useSettings } from "../../settings";
 import { COLORS, getUniqueDevices } from "../../util";
@@ -123,48 +123,6 @@ type StreamSettingsProps = {
   isDesktop: boolean;
   stream: MediaStream | null;
 }
-
-export const DesktopAudioInfo: React.FC<{ stream: MediaStream }> = ({ stream }) => {
-  const { t } = useTranslation();
-  const hasAudio = stream.getAudioTracks().length;
-
-  return (
-    <div css={{
-      position: "absolute",
-      top: 12,
-      right: 12,
-      whiteSpace: "pre-line",
-    }}>
-      <WithTooltip
-        placement="bottom"
-        tooltip={t(hasAudio ? "desktop-audio-info" : "no-desktop-audio-info")}
-      >
-        <ProtoButton
-          css={{
-            display: "inline-block",
-            backgroundColor: "rgba(0, 0, 0, 0.7)",
-            color: "white",
-            borderRadius: 5,
-            padding: 4,
-            fontSize: 15,
-            backdropFilter: "invert(1)",
-            lineHeight: 0,
-            cursor: "pointer",
-            "&:hover, &:focus-visible": {
-              backgroundColor: "rgba(0, 0, 0, 0.9)",
-            },
-            "&:focus-visible": {
-              outline: "5px dashed white",
-              outlineOffset: -2.5,
-            },
-          }}
-        >
-          <FiInfo /> {hasAudio ? <FiVolume2 /> : <FiVolumeX />}
-        </ProtoButton>
-      </WithTooltip>
-    </div>
-  );
-};
 
 export const StreamSettings: React.FC<StreamSettingsProps> = ({ isDesktop, stream }) => {
   const dispatch = useDispatch();

--- a/src/steps/video-setup/prefs.tsx
+++ b/src/steps/video-setup/prefs.tsx
@@ -124,20 +124,12 @@ type StreamSettingsProps = {
   stream: MediaStream | null;
 }
 
-export const DesktopAudioInfo: React.FC<StreamSettingsProps> = ({ isDesktop, stream }) => {
+export const DesktopAudioInfo: React.FC<{ stream: MediaStream }> = ({ stream }) => {
   const { t } = useTranslation();
-  const audioLength = stream?.getAudioTracks().length;
-
-  const hasDesktopAudio = () => {
-    if (audioLength !== undefined && audioLength > 0) {
-      return true;
-    }
-    return false;
-  };
+  const hasAudio = stream.getAudioTracks().length;
 
   return (
     <div css={{
-      display: isDesktop ? "initial" : "none",
       position: "absolute",
       top: 12,
       right: 12,
@@ -145,14 +137,14 @@ export const DesktopAudioInfo: React.FC<StreamSettingsProps> = ({ isDesktop, str
     }}>
       <WithTooltip
         placement="bottom"
-        tooltip={hasDesktopAudio() ? t("desktop-audio-info") : t("no-desktop-audio-info")}
+        tooltip={t(hasAudio ? "desktop-audio-info" : "no-desktop-audio-info")}
       >
         <ProtoButton
           css={{
             display: "inline-block",
             backgroundColor: "rgba(0, 0, 0, 0.7)",
             color: "white",
-            borderRadius: "5px",
+            borderRadius: 5,
             padding: 4,
             fontSize: 15,
             backdropFilter: "invert(1)",
@@ -167,7 +159,7 @@ export const DesktopAudioInfo: React.FC<StreamSettingsProps> = ({ isDesktop, str
             },
           }}
         >
-          <FiInfo /> {hasDesktopAudio() ? <FiVolume2 /> : <FiVolumeX />}
+          <FiInfo /> {hasAudio ? <FiVolume2 /> : <FiVolumeX />}
         </ProtoButton>
       </WithTooltip>
     </div>

--- a/src/steps/video-setup/prefs.tsx
+++ b/src/steps/video-setup/prefs.tsx
@@ -18,6 +18,7 @@ import {
   stopUserCapture,
 } from "../../capturer";
 import { Select } from "../../ui/Select";
+import { OVERLAY_STYLE } from "./preview";
 
 
 /**
@@ -218,28 +219,13 @@ export const StreamSettings: React.FC<StreamSettingsProps> = ({ isDesktop, strea
             onClick={() => setIsExpanded(old => !old)}
             aria-label={label}
             css={{
-              border: "none",
-              display: "inline-block",
-              backgroundColor: "rgba(0, 0, 0, 0.3)",
-              color: "white",
-              padding: 8,
+              ...OVERLAY_STYLE,
               fontSize: 26,
-              backdropFilter: "invert(0.3) blur(4px)",
-              lineHeight: 0,
-              borderRadius: "10px",
-              cursor: "pointer",
-              "&:hover, &:focus-visible": {
-                backgroundColor: "rgba(0, 0, 0, 0.5)",
-              },
               "> svg": {
                 transition: "transform 0.2s",
               },
               "&:hover > svg, &:focus > svg": {
                 transform: isExpanded ? "none" : "rotate(45deg)",
-              },
-              "&:focus-visible": {
-                outline: "5px dashed white",
-                outlineOffset: -2.5,
               },
             }}
           >

--- a/src/steps/video-setup/prefs.tsx
+++ b/src/steps/video-setup/prefs.tsx
@@ -6,7 +6,7 @@ import {
   Floating, FloatingContainer, FloatingHandle, FloatingTrigger, ProtoButton,
   WithTooltip, screenWidthAtMost, useColorScheme,
 } from "@opencast/appkit";
-import { FiSettings, FiX } from "react-icons/fi";
+import { FiSettings, FiX, FiInfo, FiVolumeX, FiVolume2 } from "react-icons/fi";
 
 import { Settings, useSettings } from "../../settings";
 import { COLORS, getUniqueDevices } from "../../util";
@@ -123,6 +123,56 @@ type StreamSettingsProps = {
   isDesktop: boolean;
   stream: MediaStream | null;
 }
+
+export const DesktopAudioInfo: React.FC<StreamSettingsProps> = ({ isDesktop, stream }) => {
+  const { t } = useTranslation();
+  const audioLength = stream?.getAudioTracks().length;
+
+  const hasDesktopAudio = () => {
+    if (audioLength !== undefined && audioLength > 0) {
+      return true;
+    }
+    return false;
+  };
+
+  return (
+    <div css={{
+      display: isDesktop ? "initial" : "none",
+      position: "absolute",
+      top: 12,
+      right: 12,
+      whiteSpace: "pre-line",
+    }}>
+      <WithTooltip
+        placement="bottom"
+        tooltip={hasDesktopAudio() ? t("desktop-audio-info") : t("no-desktop-audio-info")}
+      >
+        <ProtoButton
+          css={{
+            display: "inline-block",
+            backgroundColor: "rgba(0, 0, 0, 0.7)",
+            color: "white",
+            borderRadius: "5px",
+            padding: 4,
+            fontSize: 15,
+            backdropFilter: "invert(1)",
+            lineHeight: 0,
+            cursor: "pointer",
+            "&:hover, &:focus-visible": {
+              backgroundColor: "rgba(0, 0, 0, 0.9)",
+            },
+            "&:focus-visible": {
+              outline: "5px dashed white",
+              outlineOffset: -2.5,
+            },
+          }}
+        >
+          <FiInfo /> {hasDesktopAudio() ? <FiVolume2 /> : <FiVolumeX />}
+        </ProtoButton>
+      </WithTooltip>
+    </div>
+  );
+};
 
 export const StreamSettings: React.FC<StreamSettingsProps> = ({ isDesktop, stream }) => {
   const dispatch = useDispatch();

--- a/src/steps/video-setup/preview.tsx
+++ b/src/steps/video-setup/preview.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useRef } from "react";
-import { Spinner, match, unreachable, useColorScheme } from "@opencast/appkit";
+import { ProtoButton, Spinner, WithTooltip, match, unreachable, useColorScheme } from "@opencast/appkit";
 import { useTranslation } from "react-i18next";
+import { FiInfo, FiVolume2, FiVolumeX } from "react-icons/fi";
 
 import { COLORS, dimensionsOf } from "../../util";
-import { StreamSettings, DesktopAudioInfo } from "./prefs";
-import { Input } from ".";
 import { VideoBox, useVideoBoxResize } from "../../ui/VideoBox";
 import { ErrorBox } from "../../ui/ErrorBox";
+import { StreamSettings } from "./prefs";
+import { Input } from ".";
 
 
 
@@ -145,6 +146,48 @@ const PreviewVideo: React.FC<{ input: Input }> = ({ input }) => {
           borderRadius: 12,
         }}
       />
+    </div>
+  );
+};
+
+export const DesktopAudioInfo: React.FC<{ stream: MediaStream }> = ({ stream }) => {
+  const { t } = useTranslation();
+  const hasAudio = stream.getAudioTracks().length;
+
+  return (
+    <div css={{
+      position: "absolute",
+      top: 12,
+      right: 12,
+      whiteSpace: "pre-line",
+    }}>
+      <WithTooltip
+        placement="bottom"
+        tooltip={t(hasAudio ? "desktop-audio-info" : "no-desktop-audio-info")}
+      >
+        <ProtoButton
+          css={{
+            display: "inline-block",
+            backgroundColor: "rgba(0, 0, 0, 0.7)",
+            color: "white",
+            borderRadius: 5,
+            padding: 4,
+            fontSize: 15,
+            backdropFilter: "invert(1)",
+            lineHeight: 0,
+            cursor: "pointer",
+            "&:hover, &:focus-visible": {
+              backgroundColor: "rgba(0, 0, 0, 0.9)",
+            },
+            "&:focus-visible": {
+              outline: "5px dashed white",
+              outlineOffset: -2.5,
+            },
+          }}
+        >
+          <FiInfo /> {hasAudio ? <FiVolume2 /> : <FiVolumeX />}
+        </ProtoButton>
+      </WithTooltip>
     </div>
   );
 };

--- a/src/steps/video-setup/preview.tsx
+++ b/src/steps/video-setup/preview.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react";
-import { ProtoButton, Spinner, WithTooltip, match, unreachable, useColorScheme } from "@opencast/appkit";
-import { useTranslation } from "react-i18next";
-import { FiInfo, FiVolume2, FiVolumeX } from "react-icons/fi";
+import { Spinner, WithTooltip, match, unreachable, useColorScheme } from "@opencast/appkit";
+import { Trans, useTranslation } from "react-i18next";
+import { LuInfo, LuVolume2, LuVolumeX } from "react-icons/lu";
 
 import { COLORS, dimensionsOf } from "../../util";
 import { VideoBox, useVideoBoxResize } from "../../ui/VideoBox";
@@ -65,7 +65,7 @@ const StreamPreview: React.FC<{ input: Input }> = ({ input }) => {
     }}>
       <PreviewVideo input={input} />
       {input.stream && <>
-        {input.isDesktop && <DesktopAudioInfo stream={input.stream} />}
+        {input.isDesktop && <DisplayAudioInfo stream={input.stream} />}
         <StreamSettings isDesktop={input.isDesktop} stream={input.stream} />
       </>}
     </div>
@@ -150,44 +150,48 @@ const PreviewVideo: React.FC<{ input: Input }> = ({ input }) => {
   );
 };
 
-export const DesktopAudioInfo: React.FC<{ stream: MediaStream }> = ({ stream }) => {
-  const { t } = useTranslation();
+export const DisplayAudioInfo: React.FC<{ stream: MediaStream }> = ({ stream }) => {
   const hasAudio = stream.getAudioTracks().length;
 
   return (
     <div css={{
       position: "absolute",
-      top: 12,
-      right: 12,
-      whiteSpace: "pre-line",
+      top: 8,
+      right: 8,
     }}>
       <WithTooltip
-        placement="bottom"
-        tooltip={t(hasAudio ? "desktop-audio-info" : "no-desktop-audio-info")}
+        placement="top"
+        tooltip={
+          <Trans i18nKey={
+            `steps.video.${hasAudio ? "display-audio-shared" : "display-audio-not-shared"}`
+          }>
+            <strong>Note:</strong> Explanation.
+          </Trans>
+        }
       >
-        <ProtoButton
-          css={{
-            display: "inline-block",
-            backgroundColor: "rgba(0, 0, 0, 0.7)",
-            color: "white",
-            borderRadius: 5,
-            padding: 4,
-            fontSize: 15,
-            backdropFilter: "invert(1)",
-            lineHeight: 0,
-            cursor: "pointer",
-            "&:hover, &:focus-visible": {
-              backgroundColor: "rgba(0, 0, 0, 0.9)",
-            },
-            "&:focus-visible": {
-              outline: "5px dashed white",
-              outlineOffset: -2.5,
-            },
-          }}
-        >
-          <FiInfo /> {hasAudio ? <FiVolume2 /> : <FiVolumeX />}
-        </ProtoButton>
+        <div css={{ ...OVERLAY_STYLE, fontSize: 15 }}>
+          <LuInfo /> {hasAudio ? <LuVolume2 /> : <LuVolumeX />}
+        </div>
       </WithTooltip>
     </div>
   );
+};
+
+export const OVERLAY_STYLE = {
+  border: "none",
+  display: "inline-block",
+  backgroundColor: "rgba(0, 0, 0, 0.3)",
+  color: "white",
+  padding: 8,
+  backdropFilter: "invert(0.3) blur(4px)",
+  lineHeight: 0,
+  borderRadius: 10,
+  cursor: "pointer",
+  "&:hover, &:focus-visible": {
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+  },
+  "&:focus-visible": {
+    outline: "5px dashed white",
+    outlineOffset: -2.5,
+  },
 };

--- a/src/steps/video-setup/preview.tsx
+++ b/src/steps/video-setup/preview.tsx
@@ -63,8 +63,10 @@ const StreamPreview: React.FC<{ input: Input }> = ({ input }) => {
       },
     }}>
       <PreviewVideo input={input} />
-      <DesktopAudioInfo isDesktop={input.isDesktop} stream={input.stream} />
-      {input.stream && <StreamSettings isDesktop={input.isDesktop} stream={input.stream} />}
+      {input.stream && <>
+        {input.isDesktop && <DesktopAudioInfo stream={input.stream} />}
+        <StreamSettings isDesktop={input.isDesktop} stream={input.stream} />
+      </>}
     </div>
   );
 };

--- a/src/steps/video-setup/preview.tsx
+++ b/src/steps/video-setup/preview.tsx
@@ -3,7 +3,7 @@ import { Spinner, match, unreachable, useColorScheme } from "@opencast/appkit";
 import { useTranslation } from "react-i18next";
 
 import { COLORS, dimensionsOf } from "../../util";
-import { StreamSettings } from "./prefs";
+import { StreamSettings, DesktopAudioInfo } from "./prefs";
 import { Input } from ".";
 import { VideoBox, useVideoBoxResize } from "../../ui/VideoBox";
 import { ErrorBox } from "../../ui/ErrorBox";
@@ -63,6 +63,7 @@ const StreamPreview: React.FC<{ input: Input }> = ({ input }) => {
       },
     }}>
       <PreviewVideo input={input} />
+      <DesktopAudioInfo isDesktop={input.isDesktop} stream={input.stream} />
       {input.stream && <StreamSettings isDesktop={input.isDesktop} stream={input.stream} />}
     </div>
   );


### PR DESCRIPTION
This PR allows Studio to record desktop audio and resolves #551

Unfortunately, not all browsers are supported yet, as you can see [here](https://caniuse.com/mdn-api_mediadevices_getdisplaymedia_audio_capture_support) and as Lukas mentioned here: [#551](https://github.com/elan-ev/opencast-studio/issues/551)

The users get a hint after selecting display as source, with which browsers they can record desktop audio.


Output of the recordings for download:

**Only camera recorded:** Nothing changed, the finished camera video will contain microphone audio (if recorded)

**Only display recorded:** If the user recorded both, desktop audio and microphone audio, the finished video will have both audio tracks.

**Display and camera recorded:** The finished desktop video will contain desktop audio and the finished camera video will contain the microphone audio

**One thing/problem:**
In the "Review & trim" step (also after uploading to Opencast), if both the display AND the camera were recorded: you only hear the microphone audio or nothing (depending on whether microphone audio was recorded or not). I'm not entirely sure why.
The audio is correct and audible for each of the videos that can be downloaded in the last step in Studio.