### PR TITLE
Configure dependabot: remove outdated entries and group simple updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,37 +5,9 @@ updates:
   schedule:
     interval: monthly
     time: "04:00"
-  open-pull-requests-limit: 15
-  ignore:
-  - dependency-name: react-hook-form
-    versions:
-    - ">= 4.a"
-    - "< 5"
-  - dependency-name: react-hook-form
-    versions:
-    - ">= 5.a"
-    - "< 6"
-  - dependency-name: react-hook-form
-    versions:
-    - ">= 6.a"
-    - "< 7"
-  - dependency-name: react-scripts
-    versions:
-    - ">= 4.a"
-    - "< 5"
-  - dependency-name: "@sentry/browser"
-    versions:
-    - ">= 6.a"
-    - "< 7"
-  - dependency-name: "@testing-library/react"
-    versions:
-    - ">= 10.a"
-    - "< 11"
-  - dependency-name: "@testing-library/react"
-    versions:
-    - ">= 11.a"
-    - "< 12"
-  - dependency-name: use-resize-observer
-    versions:
-    - ">= 7.a"
-    - "< 8"
+  groups:
+    minor-and-patch:
+      update-types:
+      - "minor"
+      - "patch"
+


### PR DESCRIPTION
The ignored dependencies are either not used anymore or used in the newest version, so all those ignore entries were removed. Further, we will now use the grouped updates to decrease the number of pull requests (and thus also test deployments). It's very safe to just group minor and patch updates. In the rare case something fails, we can still do it manually.

Relevant docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file