### PR TITLE
Improve wording of return button when no label is given

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -37,7 +37,7 @@
   "save-creation-warn-login-failed": "Die Anmeldung beim Opencast-Server schlug fehl. Bitte prüfen Sie Ihre Anmeldedaten in <1>den Einstellungen</1>.",
 
   "save-creation-return-to": "Beenden und zurück ({{label}})",
-  "save-creation-return-to-no-label": "Beenden und zurück zur vorherigen Seite",
+  "save-creation-return-to-no-label": "Opencast Studio beenden und zurück",
   "save-creation-new-recording": "Neue Aufzeichnung starten",
   "save-creation-new-recording-warning": "Wenn Sie eine neue Aufzeichnung starten, werden die derzeitigen Aufzeichnungen in dieser Applikation verworfen (herunter- oder hochgeladene Aufzeichnung bleiben aber erhalten). Sind Sie sicher?",
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -35,7 +35,7 @@
   "save-creation-warn-login-failed": "Logging into the Opencast server failed. Please check your login credentials in <1>the settings</1>.",
 
   "save-creation-return-to": "Exit and go back to {{label}}",
-  "save-creation-return-to-no-label": "Exit and go back to previous page",
+  "save-creation-return-to-no-label": "Exit Opencast Studio and go back",
   "save-creation-new-recording": "Start a new recording",
   "save-creation-new-recording-warning": "By starting a new recording, the current recording(s) will be discarded in this application (any uploaded or downloaded recording(s) will not be affected). Are you sure?",
   "share-desktop": "Share desktop",


### PR DESCRIPTION
The old "back to previous page" was often understood as "go to the previous Studio step", which is wrong of course. The new translations should make it clearer what's happening.

Fixes #1060

CC @dagraf 