### PR TITLE
Remove warning triangle and center error message for video select errors

### DIFF
--- a/src/steps/recording/controls.tsx
+++ b/src/steps/recording/controls.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from "react-i18next";
 import { WithTooltip, match, useColorScheme } from "@opencast/appkit";
 import { FiPause, FiPlay } from "react-icons/fi";
 
-import { useStudioState } from "../../studio-state";
 import { RecordingState } from ".";
 import { SHORTCUTS, ShortcutKeys, useShortcut, useShowAvailableShortcuts } from "../../shortcuts";
 import { COLORS } from "../../util";
@@ -14,7 +13,6 @@ import { COLORS } from "../../util";
 type Props = {
   recordingState: RecordingState;
   startRecording: () => void;
-  stopRecording: (premature: boolean) => void;
   pauseRecording: () => void;
   resumeRecording: () => void;
 };
@@ -22,7 +20,6 @@ type Props = {
 export const RecordingControls: React.FC<Props> = ({
   recordingState,
   startRecording,
-  stopRecording,
   pauseRecording,
   resumeRecording,
 }) => {
@@ -30,19 +27,6 @@ export const RecordingControls: React.FC<Props> = ({
   const isLight = useColorScheme().scheme === "light";
   const { isHighContrast } = useColorScheme();
   const fgColor = isLight ? COLORS.neutral05 : COLORS.neutral90;
-
-  const { userUnexpectedEnd, displayUnexpectedEnd, audioUnexpectedEnd } = useStudioState();
-
-
-  // Detect if a stream ended unexpectedly. In that case we want to stop the
-  // recording completely.
-  useEffect(() => {
-    const unexpectedEnd = userUnexpectedEnd || displayUnexpectedEnd || audioUnexpectedEnd;
-    if (unexpectedEnd && (recordingState === "recording" || recordingState === "paused")) {
-      stopRecording(true);
-    }
-  });
-
 
   const showAvailableShortcuts = useShowAvailableShortcuts();
   useShortcut(SHORTCUTS.recording.startPauseResume, () => {

--- a/src/steps/recording/index.tsx
+++ b/src/steps/recording/index.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from "react-i18next";
 import { useEffect, useRef, useState } from "react";
 import { useBeforeunload } from "react-beforeunload";
 import { keyframes } from "@emotion/react";
-import { FiAlertTriangle, FiPauseCircle } from "react-icons/fi";
+import { FiPauseCircle } from "react-icons/fi";
 
 import {
   useStudioState, useDispatch, Dispatcher, Recording as StudioRecording,
@@ -14,7 +14,7 @@ import { StepProps } from "..";
 import { ErrorBox } from "../../ui/ErrorBox";
 import { StepContainer } from "../elements";
 import { VideoBox, VideoBoxProps, useVideoBoxResize } from "../../ui/VideoBox";
-import { COLORS, dimensionsOf } from "../../util";
+import { dimensionsOf } from "../../util";
 import { RecordingControls } from "./controls";
 import Recorder, { OnStopCallback } from "./recorder";
 import { useSettings } from "../../settings";
@@ -122,12 +122,14 @@ export const Recording: React.FC<StepProps> = ({ goToNextStep, goToPrevStep }) =
     previews.push({
       body: <StreamPreview stream={displayStream} paused={paused} />,
       dimensions: () => dimensionsOf(displayStream),
+      autoSize: !displayStream,
     });
   }
   if (userStream || userUnexpectedEnd) {
     previews.push({
       body: <StreamPreview stream={userStream} paused={paused} />,
       dimensions: () => dimensionsOf(userStream),
+      autoSize: !userStream,
     });
   }
 
@@ -150,9 +152,6 @@ export const Recording: React.FC<StepProps> = ({ goToNextStep, goToPrevStep }) =
         label: t("stop-button-title"),
       }}
     >
-      {(displayUnexpectedEnd || userUnexpectedEnd) && (
-        <ErrorBox body={t("error-lost-video-stream")} />
-      )}
       {audioUnexpectedEnd && (
         <ErrorBox body={t("error-lost-audio-stream")} />
       )}
@@ -179,6 +178,7 @@ type StreamPreviewProps = {
 };
 
 const StreamPreview: React.FC<StreamPreviewProps> = ({ stream, paused }) => {
+  const { t } = useTranslation();
   const resizeVideoBox = useVideoBoxResize();
   const videoRef = useRef<HTMLVideoElement>(null);
   const { isHighContrast } = useColorScheme();
@@ -202,18 +202,7 @@ const StreamPreview: React.FC<StreamPreviewProps> = ({ stream, paused }) => {
   });
 
   if (!stream) {
-    return (
-      <div css={{
-        width: "100%",
-        height: "100%",
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        color: COLORS.danger4,
-      }}>
-        <FiAlertTriangle size={48} />
-      </div>
-    );
+    return <ErrorBox css={{ margin: 0 }} body={t("error-lost-video-stream")} />;
   }
 
   return (

--- a/src/steps/recording/index.tsx
+++ b/src/steps/recording/index.tsx
@@ -107,6 +107,15 @@ export const Recording: React.FC<StepProps> = ({ goToNextStep, goToPrevStep }) =
     videoRecorder.current?.resume();
   };
 
+  // Detect if a stream ended unexpectedly. In that case we want to stop the
+  // recording completely.
+  useEffect(() => {
+    const unexpectedEnd = userUnexpectedEnd || displayUnexpectedEnd || audioUnexpectedEnd;
+    if (unexpectedEnd && (recordingState === "recording" || recordingState === "paused")) {
+      stopRecording(true);
+    }
+  });
+
   const paused = recordingState === "paused";
   const previews: VideoBoxProps["children"] = [];
   if (displayStream || displayUnexpectedEnd) {
@@ -153,7 +162,6 @@ export const Recording: React.FC<StepProps> = ({ goToNextStep, goToPrevStep }) =
         {canRecord && (
           <RecordingControls {...{
             startRecording,
-            stopRecording,
             pauseRecording,
             resumeRecording,
             recordingState,

--- a/src/steps/video-setup/preview.tsx
+++ b/src/steps/video-setup/preview.tsx
@@ -23,18 +23,18 @@ export const SourcePreview: React.FC<SourcePreviewProps> = ({ inputs }) => {
     1: () => [{
       body: <StreamPreview input={inputs[0]} />,
       dimensions: () => dimensionsOf(inputs[0].stream),
-      calculatedHeight: (inputs[0].allowed !== false && inputs[0].unexpectedEnd === false),
+      autoSize: inputs[0].allowed === false || inputs[0].unexpectedEnd === true,
     }],
     2: () => [
       {
         body: <StreamPreview input={inputs[0]} />,
         dimensions: () => dimensionsOf(inputs[0].stream),
-        calculatedHeight: (inputs[0].allowed !== false && inputs[0].unexpectedEnd === false),
+        autoSize: inputs[0].allowed === false || inputs[0].unexpectedEnd === true,
       },
       {
         body: <StreamPreview input={inputs[1]} />,
         dimensions: () => dimensionsOf(inputs[1].stream),
-        calculatedHeight: (inputs[1].allowed !== false && inputs[1].unexpectedEnd === false),
+        autoSize: inputs[1].allowed === false || inputs[1].unexpectedEnd === true,
       },
     ],
   }, unreachable);

--- a/src/steps/video-setup/preview.tsx
+++ b/src/steps/video-setup/preview.tsx
@@ -23,24 +23,27 @@ export const SourcePreview: React.FC<SourcePreviewProps> = ({ inputs }) => {
     1: () => [{
       body: <StreamPreview input={inputs[0]} />,
       dimensions: () => dimensionsOf(inputs[0].stream),
-      autoSize: inputs[0].allowed === false || inputs[0].unexpectedEnd === true,
+      autoSize: inputHasError(inputs[0]),
     }],
     2: () => [
       {
         body: <StreamPreview input={inputs[0]} />,
         dimensions: () => dimensionsOf(inputs[0].stream),
-        autoSize: inputs[0].allowed === false || inputs[0].unexpectedEnd === true,
+        autoSize: inputHasError(inputs[0]),
       },
       {
         body: <StreamPreview input={inputs[1]} />,
         dimensions: () => dimensionsOf(inputs[1].stream),
-        autoSize: inputs[1].allowed === false || inputs[1].unexpectedEnd === true,
+        autoSize: inputHasError(inputs[1]),
       },
     ],
   }, unreachable);
 
   return <VideoBox gap={20}>{children}</VideoBox>;
 };
+
+const inputHasError = (input: Input): boolean =>
+  input.allowed === false || !!input.unexpectedEnd;
 
 /** Shows a single stream as preview, deals with potential errors and shows preferences UI */
 const StreamPreview: React.FC<{ input: Input }> = ({ input }) => {
@@ -51,8 +54,10 @@ const StreamPreview: React.FC<{ input: Input }> = ({ input }) => {
       height: "100%",
       backgroundColor: COLORS.neutral05,
       borderRadius: 12,
-      boxShadow: isHighContrast ? "none" : "0 6px 16px rgba(0, 0, 0, 0.2)",
       position: "relative",
+      ...!inputHasError(input) && {
+        boxShadow: isHighContrast ? "none" : "0 6px 16px rgba(0, 0, 0, 0.2)",
+      },
       ...isHighContrast && {
         outline: `1px solid ${COLORS.neutral90}`,
       },
@@ -90,11 +95,12 @@ const PreviewVideo: React.FC<{ input: Input }> = ({ input }) => {
     if (allowed === false || unexpectedEnd) {
       inner = <div>
         {allowed === false && <ErrorBox
+          css={{ margin: 0 }}
           title={t(`source-${input.isDesktop ? "display" : "user"}-not-allowed-title`)}
           body={t(`source-${input.isDesktop ? "display" : "user"}-not-allowed-text`)}
         />}
         {/* TODO: differentiate between desktop and camera for better error */}
-        {unexpectedEnd && <ErrorBox body={t("error-lost-video-stream")} />}
+        {unexpectedEnd && <ErrorBox css={{ margin: 0 }} body={t("error-lost-video-stream")} />}
       </div>;
     } else {
       inner = <Spinner size={75} css={{ color: COLORS.neutral60 }} />;

--- a/src/steps/video-setup/preview.tsx
+++ b/src/steps/video-setup/preview.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef } from "react";
 import { Spinner, match, unreachable, useColorScheme } from "@opencast/appkit";
-import { FiAlertTriangle } from "react-icons/fi";
 import { useTranslation } from "react-i18next";
 
 import { COLORS, dimensionsOf } from "../../util";
@@ -24,15 +23,18 @@ export const SourcePreview: React.FC<SourcePreviewProps> = ({ inputs }) => {
     1: () => [{
       body: <StreamPreview input={inputs[0]} />,
       dimensions: () => dimensionsOf(inputs[0].stream),
+      calculatedHeight: (inputs[0].allowed !== false && inputs[0].unexpectedEnd === false),
     }],
     2: () => [
       {
         body: <StreamPreview input={inputs[0]} />,
         dimensions: () => dimensionsOf(inputs[0].stream),
+        calculatedHeight: (inputs[0].allowed !== false && inputs[0].unexpectedEnd === false),
       },
       {
         body: <StreamPreview input={inputs[1]} />,
         dimensions: () => dimensionsOf(inputs[1].stream),
+        calculatedHeight: (inputs[1].allowed !== false && inputs[1].unexpectedEnd === false),
       },
     ],
   }, unreachable);
@@ -86,7 +88,14 @@ const PreviewVideo: React.FC<{ input: Input }> = ({ input }) => {
   if (!stream) {
     let inner: JSX.Element;
     if (allowed === false || unexpectedEnd) {
-      inner = <FiAlertTriangle css={{ fontSize: 48, color: COLORS.danger4 }} />;
+      inner = <div>
+        {allowed === false && <ErrorBox
+          title={t(`source-${input.isDesktop ? "display" : "user"}-not-allowed-title`)}
+          body={t(`source-${input.isDesktop ? "display" : "user"}-not-allowed-text`)}
+        />}
+        {/* TODO: differentiate between desktop and camera for better error */}
+        {unexpectedEnd && <ErrorBox body={t("error-lost-video-stream")} />}
+      </div>;
     } else {
       inner = <Spinner size={75} css={{ color: COLORS.neutral60 }} />;
     }
@@ -98,17 +107,6 @@ const PreviewVideo: React.FC<{ input: Input }> = ({ input }) => {
         width: "100%",
         height: "100%",
       }}>
-        {allowed === false && <ErrorBox
-          title={t(`source-${input.isDesktop ? "display" : "user"}-not-allowed-title`)}
-          body={t(`source-${input.isDesktop ? "display" : "user"}-not-allowed-text`)}
-          css={{ marginBottom: 0 }}
-        />}
-        {/* TODO: differentiate between desktop and camera for better error */}
-        {unexpectedEnd && <ErrorBox
-          body={t("error-lost-video-stream")}
-          css={{ marginBottom: 0 }}
-        />}
-
         <div css={{
           flex: "1",
           display: "flex",

--- a/src/studio-state.tsx
+++ b/src/studio-state.tsx
@@ -164,7 +164,7 @@ const reducer = (state: StudioState, action: ReducerAction): StudioState => {
     case "BLOCK_DISPLAY":
       return { ...state, displayStream: null, displayAllowed: false, displayUnexpectedEnd: false };
     case "UNSHARE_DISPLAY":
-      return { ...state, displayStream: null, displayUnexpectedEnd: false };
+      return { ...state, displayStream: null, displayAllowed: null, displayUnexpectedEnd: false };
     case "DISPLAY_UNEXPECTED_END":
       return { ...state, displayStream: null, displayUnexpectedEnd: true };
 
@@ -173,7 +173,7 @@ const reducer = (state: StudioState, action: ReducerAction): StudioState => {
     case "BLOCK_USER":
       return { ...state, userStream: null, userAllowed: false, userUnexpectedEnd: false };
     case "UNSHARE_USER":
-      return { ...state, userStream: null, userUnexpectedEnd: false };
+      return { ...state, userStream: null, userAllowed: null, userUnexpectedEnd: false };
     case "USER_UNEXPECTED_END":
       return { ...state, userStream: null, userUnexpectedEnd: true };
 

--- a/src/ui/VideoBox.tsx
+++ b/src/ui/VideoBox.tsx
@@ -21,6 +21,12 @@ export type VideoBoxProps = {
 export type VideoBoxChild = {
   body: JSX.Element;
   dimensions: () => [number, number] | null;
+  /**
+   * If `true` (default), the calculated height is set as `height` of the div.
+   * If `false`, it is not set, which allows the div to grow in height. Used to
+   * display error messages.
+   */
+  calculatedHeight?: boolean;
 };
 
 // Manages one or two children with given aspect ratio.
@@ -104,7 +110,7 @@ export const VideoBox: React.FC<VideoBoxProps> = ({
         <VideoBoxResizeContext.Provider value={resizeVideoBox}>
           <div ref={ref} css={{ flex: "1 0 0", minHeight, display: "flex" }}>
             <div css={{
-              height: childHeight,
+              height: (child.calculatedHeight ?? true) ? childHeight : undefined,
               width: childWidth,
               minWidth: `${minWidth}px`,
               margin: "auto",
@@ -213,7 +219,7 @@ export const VideoBox: React.FC<VideoBoxProps> = ({
             }}
           >
             <div css={{
-              height: heights[0],
+              height: (children[0].calculatedHeight ?? true) ? heights[0] : undefined,
               width: widths[0],
               minWidth: `${minWidth}px`,
               margin: "auto",
@@ -221,7 +227,7 @@ export const VideoBox: React.FC<VideoBoxProps> = ({
               { children[0].body }
             </div>
             <div css={{
-              height: heights[1],
+              height: (children[1].calculatedHeight ?? true) ? heights[1] : undefined,
               width: widths[1],
               minWidth: `${minWidth}px`,
               margin: "auto",

--- a/src/ui/VideoBox.tsx
+++ b/src/ui/VideoBox.tsx
@@ -22,11 +22,11 @@ export type VideoBoxChild = {
   body: JSX.Element;
   dimensions: () => [number, number] | null;
   /**
-   * If `true` (default), the calculated height is set as `height` of the div.
-   * If `false`, it is not set, which allows the div to grow in height. Used to
-   * display error messages.
+   * If `false` (default), the calculated size is used for the divs. Otherwise,
+   * `width` and `height` are unset, which means the div takes the size of its
+   * child. Used for error messages.
    */
-  calculatedHeight?: boolean;
+  autoSize?: boolean;
 };
 
 // Manages one or two children with given aspect ratio.
@@ -110,8 +110,10 @@ export const VideoBox: React.FC<VideoBoxProps> = ({
         <VideoBoxResizeContext.Provider value={resizeVideoBox}>
           <div ref={ref} css={{ flex: "1 0 0", minHeight, display: "flex" }}>
             <div css={{
-              height: (child.calculatedHeight ?? true) ? childHeight : undefined,
-              width: childWidth,
+              ...!child.autoSize && {
+                height: childHeight,
+                width: childWidth,
+              },
               minWidth: `${minWidth}px`,
               margin: "auto",
             }}>
@@ -213,22 +215,27 @@ export const VideoBox: React.FC<VideoBoxProps> = ({
             css={{
               flex: "1 0 0",
               display: "flex",
+              gap: gap,
               flexDirection,
               justifyContent: "space-between",
               minHeight,
             }}
           >
             <div css={{
-              height: (children[0].calculatedHeight ?? true) ? heights[0] : undefined,
-              width: widths[0],
+              ...!children[0].autoSize && {
+                height: heights[0],
+                width: widths[0],
+              },
               minWidth: `${minWidth}px`,
               margin: "auto",
             }}>
               { children[0].body }
             </div>
             <div css={{
-              height: (children[1].calculatedHeight ?? true) ? heights[1] : undefined,
-              width: widths[1],
+              ...!children[1].autoSize && {
+                height: heights[1],
+                width: widths[1],
+              },
               minWidth: `${minWidth}px`,
               margin: "auto",
             }}>


### PR DESCRIPTION
Fixes #1103

This also fixes this error case for narrow screens where the error message previously overflowed the container, sometimes even the viewport.

Test deployment: https://test.studio.opencast.org/2023-09-26_12-46-54-pr1113-6312834670/