### PR TITLE
Replace `cmd` hotkey declaration with `mod`

### DIFF
--- a/src/shortcuts.tsx
+++ b/src/shortcuts.tsx
@@ -17,8 +17,8 @@ export const SHORTCUTS = {
     showOverview: "?",
     closeOverlay: "Escape",
     tab: "Tab",
-    prev: onMac() ? "Shift+Cmd+left" : "Mod+left",
-    next: onMac() ? "Shift+Cmd+right" : "Mod+right",
+    prev: onMac() ? "Shift+Mod+left" : "Mod+left",
+    next: onMac() ? "Shift+Mod+right" : "Mod+right",
   },
   videoSetup: {
     selectScreen: "1",


### PR DESCRIPTION
Apparently `cmd` is not a valid keycode (anymore?).

Fixes #1100 