### PR TITLE
Show lowercase letters in shortcut overview/overlay

### DIFF
--- a/src/shortcuts.tsx
+++ b/src/shortcuts.tsx
@@ -13,7 +13,7 @@ const onMac = () => navigator.userAgent.includes("Mac");
 
 export const SHORTCUTS = {
   general: {
-    showAvailableShortcuts: "Alt; S",
+    showAvailableShortcuts: "Alt; s",
     showOverview: "?",
     closeOverlay: "Escape",
     tab: "Tab",
@@ -30,22 +30,22 @@ export const SHORTCUTS = {
     withoutAudio: "2",
   },
   recording: {
-    startPauseResume: "K; Space",
+    startPauseResume: "k; Space",
   },
   review: {
-    playPause: "K; Space",
-    forwards5secs: "L; right",
-    backwards5secs: "J; left",
+    playPause: "k; Space",
+    forwards5secs: "l; right",
+    backwards5secs: "j; left",
     forwardsFrame: ".",
     backwardsFrame: ",",
-    cutLeft: "N",
-    cutRight: "M",
-    removeCutLeft: "Shift+N",
-    removeCutRight: "Shift+M",
+    cutLeft: "n",
+    cutRight: "m",
+    removeCutLeft: "Shift+n",
+    removeCutRight: "Shift+m",
   },
   finish: {
-    startNewRecording: "Shift+N",
-    download: "D",
+    startNewRecording: "Shift+n",
+    download: "d",
   },
 } as const;
 
@@ -161,7 +161,7 @@ export const ShortcutKeys: React.FC<ShortcutKeysProps> = ({ shortcut, large = fa
       return (
         <React.Fragment key={i}>
           {i !== 0 && "+"}
-          <SingleKey large={large}>{child}</SingleKey>
+          <SingleKey large={large} monofont={key === "l"}>{child}</SingleKey>
         </React.Fragment>
       );
     })}
@@ -170,9 +170,11 @@ export const ShortcutKeys: React.FC<ShortcutKeysProps> = ({ shortcut, large = fa
 
 type SingleKeyProps = React.PropsWithChildren<{
   large: boolean;
+  /** Whether to use `monospace` font for this one. Basically only useful for lowercase l. */
+  monofont: boolean;
 }>;
 
-const SingleKey: React.FC<SingleKeyProps> = ({ large, children }) => {
+const SingleKey: React.FC<SingleKeyProps> = ({ large, monofont, children }) => {
   const isLight = useColorScheme().scheme === "light";
 
   return (
@@ -192,6 +194,7 @@ const SingleKey: React.FC<SingleKeyProps> = ({ large, children }) => {
         : COLORS.neutral10,
       color: (isLight || !large) ? COLORS.neutral80 : COLORS.neutral90,
       cursor: "default",
+      ...monofont && { fontFamily: "monospace" },
     }}>
       {children}
     </div>


### PR DESCRIPTION
Fixes #1115

Unfortunately, the lowercase l in Roboto (our font) is indistinguishable from uppercase I, so we special case that and use monospace font for that. Not ideal but clarity is more important here.