### PR TITLE
Fix safari not capturing both display and camera

### DIFF
--- a/src/capturer.tsx
+++ b/src/capturer.tsx
@@ -25,7 +25,7 @@ export async function startAudioCapture(dispatch: Dispatcher, deviceId?: Constra
     });
     stream.getTracks().forEach(track => {
       track.onended = () => {
-        dispatch({ type: "AUDIO_UNEXPETED_END" });
+        dispatch({ type: "AUDIO_UNEXPECTED_END" });
       };
     });
 
@@ -62,7 +62,7 @@ export async function startDisplayCapture(
     const stream = await navigator.mediaDevices.getDisplayMedia(constraints);
     stream.getTracks().forEach(track => {
       track.onended = () => {
-        dispatch({ type: "DISPLAY_UNEXPETED_END" });
+        dispatch({ type: "DISPLAY_UNEXPECTED_END" });
       };
     });
 
@@ -99,7 +99,7 @@ export async function startUserCapture(
     const stream = await navigator.mediaDevices.getUserMedia(constraints);
     stream.getTracks().forEach(track => {
       track.onended = () => {
-        dispatch({ type: "USER_UNEXPETED_END" });
+        dispatch({ type: "USER_UNEXPECTED_END" });
       };
     });
     dispatch({ type: "SHARE_USER", stream });

--- a/src/studio-state.tsx
+++ b/src/studio-state.tsx
@@ -112,15 +112,15 @@ type ReducerAction =
   | { type: "SHARE_AUDIO"; stream: MediaStream }
   | { type: "BLOCK_AUDIO" }
   | { type: "UNSHARE_AUDIO" }
-  | { type: "AUDIO_UNEXPETED_END" }
+  | { type: "AUDIO_UNEXPECTED_END" }
   | { type: "SHARE_DISPLAY"; stream: MediaStream }
   | { type: "BLOCK_DISPLAY" }
   | { type: "UNSHARE_DISPLAY" }
-  | { type: "DISPLAY_UNEXPETED_END" }
+  | { type: "DISPLAY_UNEXPECTED_END" }
   | { type: "SHARE_USER"; stream: MediaStream }
   | { type: "BLOCK_USER" }
   | { type: "UNSHARE_USER" }
-  | { type: "USER_UNEXPETED_END" }
+  | { type: "USER_UNEXPECTED_END" }
   | { type: "START_RECORDING" }
   | { type: "STOP_RECORDING" }
   | { type: "STOP_RECORDING_PREMATURELY" }
@@ -153,7 +153,7 @@ const reducer = (state: StudioState, action: ReducerAction): StudioState => {
     case "BLOCK_AUDIO":
       return { ...state, audioStream: null, audioAllowed: false, audioUnexpectedEnd: false };
     case "UNSHARE_AUDIO": return { ...state, audioStream: null, audioUnexpectedEnd: false };
-    case "AUDIO_UNEXPETED_END": return { ...state, audioStream: null, audioUnexpectedEnd: true };
+    case "AUDIO_UNEXPECTED_END": return { ...state, audioStream: null, audioUnexpectedEnd: true };
 
     case "SHARE_DISPLAY": return {
       ...state,
@@ -165,7 +165,7 @@ const reducer = (state: StudioState, action: ReducerAction): StudioState => {
       return { ...state, displayStream: null, displayAllowed: false, displayUnexpectedEnd: false };
     case "UNSHARE_DISPLAY":
       return { ...state, displayStream: null, displayUnexpectedEnd: false };
-    case "DISPLAY_UNEXPETED_END":
+    case "DISPLAY_UNEXPECTED_END":
       return { ...state, displayStream: null, displayUnexpectedEnd: true };
 
     case "SHARE_USER":
@@ -174,7 +174,7 @@ const reducer = (state: StudioState, action: ReducerAction): StudioState => {
       return { ...state, userStream: null, userAllowed: false, userUnexpectedEnd: false };
     case "UNSHARE_USER":
       return { ...state, userStream: null, userUnexpectedEnd: false };
-    case "USER_UNEXPETED_END":
+    case "USER_UNEXPECTED_END":
       return { ...state, userStream: null, userUnexpectedEnd: true };
 
     case "START_RECORDING": return { ...state, isRecording: true, recordingStartTime: new Date() };


### PR DESCRIPTION
Safari needs a "user gesture" (i.e. a button click) to call `getDisplayMedia`. Calling the user capture first would prevent the display capture to register the triggering button click, so this switches the ordering (for safari only).
So in Safari, the user will always get asked to share their screen before they get asked to share their webcam.

(I did notice that when calling both `startUserCapture` and `startDisplayCapture` inside a `Promise.all()`, the ordering in Safari is consistently switched again, but with no issues (meaning user capture is asked before screen capture). This would be preferrable, but I'm not sure if we can rely on this always being the case. So in the interest of consistency I chose to just call `startDisplayCapture` first...)

Closes #934