### PR TITLE
Update to appkit 0.2.2 to use `neutral00` for input background

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@emotion/react": "^11.11.1",
         "@fontsource-variable/roboto-flex": "^5.0.8",
         "@iarna/toml": "^2.2.5",
-        "@opencast/appkit": "^0.2.1",
+        "@opencast/appkit": "^0.2.2",
         "@svgr/webpack": "^8.1.0",
         "babel-loader": "^9.1.3",
         "copy-webpack-plugin": "^11.0.0",
@@ -2317,9 +2317,9 @@
       }
     },
     "node_modules/@opencast/appkit": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@opencast/appkit/-/appkit-0.2.1.tgz",
-      "integrity": "sha512-G8tpq52kFbA/ZiPYXhrWi5METuUqNWvsQ1WISvOnK1TjedHiOpsG+tukH570546Lal5KA0lgCb26Lo4lQ6rB+g==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@opencast/appkit/-/appkit-0.2.2.tgz",
+      "integrity": "sha512-m5VY/VmIQcRK+FbGZj187TZ6l+v0ON6c7S4yB7oyZfkrlaASLWQ4ibxVpo/9VosuyxeB/iah8cgGy7Rksh+/Rg==",
       "peerDependencies": {
         "@emotion/react": "^11.11.1",
         "@floating-ui/react": "^0.24.3",
@@ -11514,9 +11514,9 @@
       }
     },
     "@opencast/appkit": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@opencast/appkit/-/appkit-0.2.1.tgz",
-      "integrity": "sha512-G8tpq52kFbA/ZiPYXhrWi5METuUqNWvsQ1WISvOnK1TjedHiOpsG+tukH570546Lal5KA0lgCb26Lo4lQ6rB+g==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@opencast/appkit/-/appkit-0.2.2.tgz",
+      "integrity": "sha512-m5VY/VmIQcRK+FbGZj187TZ6l+v0ON6c7S4yB7oyZfkrlaASLWQ4ibxVpo/9VosuyxeB/iah8cgGy7Rksh+/Rg==",
       "requires": {}
     },
     "@opencast/eslint-config-ts-react": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@emotion/react": "^11.11.1",
     "@fontsource-variable/roboto-flex": "^5.0.8",
     "@iarna/toml": "^2.2.5",
-    "@opencast/appkit": "^0.2.1",
+    "@opencast/appkit": "^0.2.2",
     "@svgr/webpack": "^8.1.0",
     "babel-loader": "^9.1.3",
     "copy-webpack-plugin": "^11.0.0",

--- a/src/index.html
+++ b/src/index.html
@@ -19,6 +19,7 @@
       /* ----- Define colors and other color-scheme dependent things ----- */
       /* Light mode */
       html[data-color-scheme="light"], html:not([data-color-scheme]) {
+        --color-neutral00: #ffffff;
         --color-neutral05: #fefefe;
         --color-neutral10: #f3f3f3;
         --color-neutral15: #e8e8e8;
@@ -49,6 +50,7 @@
 
       /* Dark mode */
       html[data-color-scheme="dark"] {
+        --color-neutral00: #111111;
         --color-neutral05: #171717;
         --color-neutral10: #1e1e1e;
         --color-neutral15: #262626;
@@ -78,6 +80,7 @@
       }
 
       html[data-color-scheme="light-high-contrast"] {
+        --color-neutral00: #fff;
         --color-neutral05: #fff;
         --color-neutral10: #fff;
         --color-neutral15: #fff;
@@ -108,6 +111,7 @@
       }
 
       html[data-color-scheme="dark-high-contrast"] {
+        --color-neutral00: #000;
         --color-neutral05: #000;
         --color-neutral10: #000;
         --color-neutral15: #000;

--- a/src/steps/finish/upload.tsx
+++ b/src/steps/finish/upload.tsx
@@ -411,7 +411,7 @@ export const Input = <I extends FieldValues, F>({
             width: "100%",
             borderRadius: 4,
             border: `1px solid ${error ? COLORS.danger4 : COLORS.neutral30}`,
-            backgroundColor: COLORS.neutral05,
+            backgroundColor: COLORS.neutral00,
             color: COLORS.neutral70,
             padding: "8px 16px",
             ...focusStyle({ offset: -1 }),


### PR DESCRIPTION
We did the same for Tobira to make the inputs look a bit better on neutral05 backgrounds.

Comparison:

**new**
![gnome-shell-screenshot-QPI5B2](https://github.com/elan-ev/opencast-studio/assets/7419664/b9269174-8c24-4d1e-b1e7-692fc7b3875d)

**old**
![gnome-shell-screenshot-YCCWB2](https://github.com/elan-ev/opencast-studio/assets/7419664/e046d2e8-1d91-478f-88bc-38a281e266be)

For the light mode, there is little difference.
