### PR TITLE
Improve link-button a11y

### DIFF
--- a/src/steps/elements.tsx
+++ b/src/steps/elements.tsx
@@ -168,7 +168,17 @@ const StepButton: React.FC<StepButtonProps> = ({
                 },
               }}>
                 {"href" in entry
-                  ? <a href={entry.href} css={style}>
+                  ? <a
+                    role="button"
+                    href={entry.href}
+                    css={style}
+                    onKeyDown={e => {
+                      if (e.key === " ") {
+                        e.preventDefault();
+                        window.location.href = entry.href;
+                      }
+                    }}
+                  >
                     {entry.icon}
                     {entry.label}
                   </a>

--- a/src/steps/finish/save-locally.tsx
+++ b/src/steps/finish/save-locally.tsx
@@ -88,6 +88,13 @@ export const SaveLocally: React.FC = () => {
           rel="noopener noreferrer"
           role="button"
           onClick={() => dispatch({ type: "MARK_DOWNLOADED", index: i })}
+          onKeyDown={e => {
+            if (e.key === " ") {
+              e.preventDefault();
+              buttons[i].current?.click();
+              dispatch({ type: "MARK_DOWNLOADED", index: i });
+            }
+          }}
           css={{
             ...sharedButtonStyle(isHighContrast),
             justifyContent: "center",


### PR DESCRIPTION
There are two places where an anchor element is styled as a button.
[Mdn web docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role#accessibility_concerns) says that in addition to `role=button`, these also need an extra handler to be usable with the `space` key (which is default button behaviour and therefore expected with things that are styled as buttons).

The other part of #630 (`aria-live` for error messages) appears to be done already.

Closes #630