### PR TITLE
Fix seeking in review & trim step

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "react-icons": "^4.12.0",
         "react-select": "^5.8.0",
         "use-resize-observer": "^9.1.0",
+        "webm-duration-fix": "^1.0.4",
         "webpack": "^5.94.0",
         "webpack-cli": "^5.1.4"
       },
@@ -4140,6 +4141,25 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -4270,6 +4290,29 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -5143,6 +5186,11 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
+    },
+    "node_modules/ebml-block": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ebml-block/-/ebml-block-1.1.2.tgz",
+      "integrity": "sha512-HgNlIsRFP6D9VKU5atCeHRJY7XkJP8bOe8yEhd8NB7B3b4++VWTyauz6g650iiPmLfPLGlVpoJmGSgMfXDYusg=="
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -6940,6 +6988,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/ignore": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
@@ -7065,6 +7132,14 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "node_modules/int64-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-1.0.1.tgz",
+      "integrity": "sha512-+3azY4pXrjAupJHU1V9uGERWlhoqNswJNji6aD/02xac7oxol508AsMC5lxKhEqyZeDFy3enq5OGWXF4u75hiw==",
+      "engines": {
+        "node": ">= 4.5.0"
+      }
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
@@ -10647,6 +10722,17 @@
       "dev": true,
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/webm-duration-fix": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/webm-duration-fix/-/webm-duration-fix-1.0.4.tgz",
+      "integrity": "sha512-kvhmSmEnuohtK+j+mJswqCCM2ViKb9W8Ch0oAxcaeUvpok5CsMORQLnea+CYKDXPG6JH12H0CbRK85qhfeZLew==",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "ebml-block": "^1.1.2",
+        "events": "^3.3.0",
+        "int64-buffer": "^1.0.1"
       }
     },
     "node_modules/webpack": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react-icons": "^4.12.0",
     "react-select": "^5.8.0",
     "use-resize-observer": "^9.1.0",
+    "webm-duration-fix": "^1.0.4",
     "webpack": "^5.94.0",
     "webpack-cli": "^5.1.4"
   },

--- a/src/steps/recording/recorder.tsx
+++ b/src/steps/recording/recorder.tsx
@@ -1,3 +1,4 @@
+import fixWebmDuration from "webm-duration-fix";
 import { Settings } from "../../settings";
 import { dimensionsOf } from "../../util";
 
@@ -61,9 +62,9 @@ export default class Recorder {
     }
   };
 
-  #onStop = (_event: Event) => {
+  #onStop = async (_event: Event) => {
     const mimeType = this.#data[0]?.type || this.#recorder.mimeType;
-    const media = new Blob(this.#data, { type: mimeType });
+    const media = await fixWebmDuration(new Blob(this.#data, { type: mimeType }));
     const url = URL.createObjectURL(media);
 
     this.#reset();


### PR DESCRIPTION
Aims at fixing or at least helping with #517.

As suggested in #517, this introduces the webm-duration-fix package to Studio. This should fix the "Preview & Trim" step on Chrome (desktop), allowing for playback and seeking in the recorded video. Furthermore, the duration should now be stored correctly in the video metadata.

This should not change behaviour in Firefox, as it was already working in Firefox. I have not tested other browsers. I have also only tested this with short (~1 minute) recordings.

Note that recordings downloaded directly from Chrome may still not be playable by all and every media player. This is not something this PR can fix.