### PR TITLE
Better validate ACL configuration

### DIFF
--- a/src/settings.tsx
+++ b/src/settings.tsx
@@ -572,11 +572,11 @@ const SCHEMA = {
         return true;
       }
 
-      if (typeof v === "string") {
+      if (typeof v === "string" && v.trim().startsWith("<")) {
         return v;
       }
 
-      throw new Error("needs to be 'true', 'false' or a string");
+      throw new Error("needs to be 'true', 'false' or an XML string");
     },
     dcc: types.string,
     titleField: metaDataField,


### PR DESCRIPTION
The ACL configuration may not be a boolean or just any string. It must be a valid XACML. While we can't easily parse the XACML and check its correctness, we can at least check if the ACL seems to be XML.

The background for this is that with Opencast 14, `acl = "false"` was a valid configuration. This silently changed with Opencast 15(?) and caused Studio to upload ACL files with the contents `false", causing problems in later processing steps of Opencast. This patch makes this at least easier to spot.