### PR TITLE
Add GitHub Actions to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,20 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: monthly
-    time: "04:00"
-  groups:
-    minor-and-patch:
-      update-types:
-      - "minor"
-      - "patch"
 
+  # GHA
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+
+  # Javascript
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+      time: "04:00"
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Getting the notification that v3 of `actions/upload-artifact` and `actions/download-artifact` will stop working on January 30th, 2025, I noticed that the Actions are not included in the Dependabot updates.

This patch adds them, so that Dependabot will suggest updates in the future.