### PR TITLE
Apply the webm duration fix only to specific MimeTypes

### DIFF
--- a/src/steps/recording/recorder.tsx
+++ b/src/steps/recording/recorder.tsx
@@ -64,7 +64,15 @@ export default class Recorder {
 
   #onStop = async (_event: Event) => {
     const mimeType = this.#data[0]?.type || this.#recorder.mimeType;
-    const media = await fixWebmDuration(new Blob(this.#data, { type: mimeType }));
+    const mainMimeType = mimeType.split(";")[0].trim();
+    let media;
+
+    if (mainMimeType === "video/webm") {
+      media = await fixWebmDuration(new Blob(this.#data, { type: mimeType }));
+    } else {
+      media = new Blob(this.#data, { type: mimeType });
+    }
+
     const url = URL.createObjectURL(media);
 
     this.#reset();

--- a/src/steps/recording/recorder.tsx
+++ b/src/steps/recording/recorder.tsx
@@ -67,7 +67,9 @@ export default class Recorder {
     const mainMimeType = mimeType.split(";")[0].trim();
     let media;
 
-    if (mainMimeType === "video/webm") {
+    const fixMimeTypes = ["video/webm", "video/x-matroska"];
+
+    if (fixMimeTypes.includes(mainMimeType)) {
       media = await fixWebmDuration(new Blob(this.#data, { type: mimeType }));
     } else {
       media = new Blob(this.#data, { type: mimeType });


### PR DESCRIPTION
This PR should fix https://github.com/elan-ev/opencast-studio/issues/1192  
fixWebmDuration is only applied if the MimeType is "video/webm" or "video/x-matroska".  
Other formats can easily be added.

Tested with Chrome and Firefox on Windows and with Chrome, Firefox and Safari on MacOS.