### PR TITLE
Add ability to specify ACL in a concise way

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "html-webpack-plugin": "^5.6.3",
         "i18next": "^24.2.2",
         "i18next-browser-languagedetector": "^8.0.2",
+        "is-plain-object": "^5.0.0",
         "mustache": "^4.2.0",
         "oscilloscope": "^1.3.0",
         "react": "^18.3.1",
@@ -4307,6 +4308,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/clone-deep/node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
@@ -7084,12 +7097,10 @@
       }
     },
     "node_modules/is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7260,6 +7271,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "html-webpack-plugin": "^5.6.3",
     "i18next": "^24.2.2",
     "i18next-browser-languagedetector": "^8.0.2",
+    "is-plain-object": "^5.0.0",
     "mustache": "^4.2.0",
     "oscilloscope": "^1.3.0",
     "react": "^18.3.1",

--- a/src/opencast.tsx
+++ b/src/opencast.tsx
@@ -4,7 +4,7 @@ import Mustache from "mustache";
 import { bug } from "@opencast/appkit";
 
 import { recordingFileName, usePresentContext } from "./util";
-import { Settings } from "./settings";
+import { Acl, DEFAULT_ACL, Settings } from "./settings";
 import { Recording } from "./studio-state";
 
 
@@ -513,9 +513,10 @@ export class Opencast {
     mediaPackage: string;
     uploadSettings: Settings["upload"];
   }) {
-    const template = uploadSettings?.acl === true || (!uploadSettings?.acl)
-      ? DEFAULT_ACL_TEMPLATE
-      : uploadSettings?.acl;
+    const aclConfig = uploadSettings?.acl;
+    const template = (aclConfig === true || !aclConfig)
+      ? aclToXmlTemplate(DEFAULT_ACL)
+      : typeof aclConfig === "string" ? aclConfig : aclToXmlTemplate(aclConfig);
     const acl = this.constructAcl(template);
 
     const body = new FormData();
@@ -810,6 +811,40 @@ const renderTemplate = (template: string, view: object): string => {
   return out;
 };
 
+const aclToXmlTemplate = (acl: Acl) => {
+  const rules = [...acl.entries()].flatMap(([role, actions], i) => actions.map((action, j) => `
+    <Rule RuleId="${i}:${j}" Effect="Permit">
+      <Target>
+        <Actions>
+          <Action>
+            <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+              <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">${action}</AttributeValue>
+              <ActionAttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id"
+                DataType="http://www.w3.org/2001/XMLSchema#string"/>
+            </ActionMatch>
+          </Action>
+        </Actions>
+      </Target>
+      <Condition>
+        <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:string-is-in">
+          <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">${role}</AttributeValue>
+          <SubjectAttributeDesignator AttributeId="urn:oasis:names:tc:xacml:2.0:subject:role"
+            DataType="http://www.w3.org/2001/XMLSchema#string"/>
+        </Apply>
+      </Condition>
+    </Rule>`,
+  ));
+
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <Policy PolicyId="mediapackage-1"
+      RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:permit-overrides"
+      Version="2.0"
+      xmlns="urn:oasis:names:tc:xacml:2.0:policy:schema:os">
+      ${rules.join("\n")}
+    </Policy>
+  `;
+};
+
 const DEFAULT_DCC_TEMPLATE = `<?xml version="1.0" encoding="UTF-8"?>
 <dublincore xmlns="http://www.opencastproject.org/xsd/1.0/dublincore/"
             xmlns:dcterms="http://purl.org/dc/terms/"
@@ -823,54 +858,6 @@ const DEFAULT_DCC_TEMPLATE = `<?xml version="1.0" encoding="UTF-8"?>
     </dcterms:temporal>
     <dcterms:spatial>Opencast Studio</dcterms:spatial>
 </dublincore>
-`;
-
-const DEFAULT_ACL_TEMPLATE = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<Policy PolicyId="mediapackage-1"
-  RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:permit-overrides"
-  Version="2.0"
-  xmlns="urn:oasis:names:tc:xacml:2.0:policy:schema:os">
-  <Rule RuleId="user_read_Permit" Effect="Permit">
-    <Target>
-      <Actions>
-        <Action>
-          <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">read</AttributeValue>
-            <ActionAttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id"
-              DataType="http://www.w3.org/2001/XMLSchema#string"/>
-          </ActionMatch>
-        </Action>
-      </Actions>
-    </Target>
-    <Condition>
-      <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:string-is-in">
-        <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">{{ user.userRole }}</AttributeValue>
-        <SubjectAttributeDesignator AttributeId="urn:oasis:names:tc:xacml:2.0:subject:role"
-          DataType="http://www.w3.org/2001/XMLSchema#string"/>
-      </Apply>
-    </Condition>
-  </Rule>
-  <Rule RuleId="user_write_Permit" Effect="Permit">
-    <Target>
-      <Actions>
-        <Action>
-          <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">write</AttributeValue>
-            <ActionAttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id"
-              DataType="http://www.w3.org/2001/XMLSchema#string"/>
-          </ActionMatch>
-        </Action>
-      </Actions>
-    </Target>
-    <Condition>
-      <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:string-is-in">
-        <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">{{ user.userRole }}</AttributeValue>
-        <SubjectAttributeDesignator AttributeId="urn:oasis:names:tc:xacml:2.0:subject:role"
-          DataType="http://www.w3.org/2001/XMLSchema#string"/>
-      </Apply>
-    </Condition>
-  </Rule>
-</Policy>
 `;
 
 const smil = ({ start, end }: { start: number; end: number }) => `

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -81,6 +81,11 @@ const config: CallableOption = (_env, argv) => ({
       patterns: [
         { from: path.join(__dirname, "assets/logo-wide.svg"), to: OUT_PATH },
         { from: path.join(__dirname, "assets/logo-narrow.svg"), to: OUT_PATH },
+        ...argv.mode === "development" ? [{
+          from: path.join(__dirname, "assets/settings.toml"),
+          to: OUT_PATH,
+          noErrorOnMissing: true,
+        }] : [],
 
         // Copy the font related files to output directory
         {


### PR DESCRIPTION
Before, one had to always specify an XML blob, which is suuuper verbose.
With this, Studio also allows a more concise representation that's also
suitable to be included in the URL. While each string in the object is
also treated as a mustache template, with the object notation, it is not
possible to conditionally add entries. At least not yet.

@ferishili you asked for this, could you take a look and tell me if it fully solves your use case?