### PR TITLE
Update `*-artifact` actions and replace manual download script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         PUBLIC_PATH=${deploydir} npm run build:release
 
     - name: Archive test deployment files as artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: test-deployment-files
         include-hidden-files: true
@@ -58,7 +58,7 @@ jobs:
 
     - name: Archive prod deployment files as artifact
       if: github.repository_owner == 'elan-ev' && github.ref == 'refs/heads/master'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: prod-deployment-files
         include-hidden-files: true

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -31,38 +31,11 @@ jobs:
           git ls-files | while read -r f; do rm -f "$f"; git rm --cached "$f"; done
         fi
 
-    # Unfortunately we cannot use `actions/download-artifact` here since that
-    # only allows to download artifacts from the same run.
     - name: Download artifacts from build workflow
-      uses: actions/github-script@v7
+      uses: actions/download-artifact@4
       with:
-        script: |
-          const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: ${{ github.event.workflow_run.id }},
-          });
-          const deployFiles = artifacts.data.artifacts
-              .filter(a => a.name == "prod-deployment-files")[0];
-          const download = await github.rest.actions.downloadArtifact({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              artifact_id: deployFiles.id,
-              archive_format: 'zip',
-          });
-
-          const fs = require('fs');
-          fs.writeFileSync('${{github.workspace}}/artifacts.zip', Buffer.from(download.data));
-
-          // The artifact is not needed anymore
-          github.rest.actions.deleteArtifact({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              artifact_id: deployFiles.id,
-          })
-
-    - name: extract artifacts
-      run: unzip artifacts.zip
+        name: prod-deployment-files
+        run-id: ${{ github.event.workflow_run.id }}
 
     - name: Prepare deployment files
       run: |

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -18,38 +18,11 @@ jobs:
         chmod 600 ~/.ssh/id_rsa
         ssh-keyscan github.com >> ~/.ssh/known_hosts
 
-    # Unfortunately we cannot use `actions/download-artifact` here since that
-    # only allows to download artifacts from the same run.
     - name: Download artifacts from build workflow
-      uses: actions/github-script@v7
+      uses: actions/download-artifact@4
       with:
-        script: |
-          const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: ${{ github.event.workflow_run.id }},
-          });
-          const deployFiles = artifacts.data.artifacts
-              .filter(a => a.name == "test-deployment-files")[0];
-          const download = await github.rest.actions.downloadArtifact({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              artifact_id: deployFiles.id,
-              archive_format: 'zip',
-          });
-
-          const fs = require('fs');
-          fs.writeFileSync('${{github.workspace}}/artifacts.zip', Buffer.from(download.data));
-
-          // The artifact is not needed anymore
-          github.rest.actions.deleteArtifact({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              artifact_id: deployFiles.id,
-          })
-
-    - name: extract artifacts
-      run: unzip artifacts.zip
+        name: test-deployment-files
+        run-id: ${{ github.event.workflow_run.id }}
 
     - name: Checkout test deployment repo
       run: |


### PR DESCRIPTION
Luckily, the new `download-artifact` allows us to specify a different workflow run ID, which required us to write our own script before.