### PR TITLE
Replace main with branch structure, and file PRs on change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,13 +47,13 @@ jobs:
 
     # Prepare production deployment
     - name: Build for prod deployment
-      if: github.repository_owner == 'opencast' && github.ref == 'refs/heads/main'
+      if: github.repository_owner == 'opencast' && github.ref_name == 'develop'
       run: |
         rm -rf build
         npm run build:release
 
     - name: Archive prod deployment files as artifact
-      if: github.repository_owner == 'opencast' && github.ref == 'refs/heads/main'
+      if: github.repository_owner == 'opencast' && github.ref_name == 'develop'
       uses: actions/upload-artifact@v7
       with:
         name: prod-deployment-files

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,9 +1,9 @@
-name: Deploy main
+name: Deploy develop
 
 on:
   workflow_run:
     workflows: ["Build & test"]
-    branches: [main]
+    branches: [develop]
     types: [completed]
 
 jobs:

--- a/.github/workflows/file-pr.yml
+++ b/.github/workflows/file-pr.yml
@@ -1,0 +1,72 @@
+name: File upstream PR
+
+on:
+  push:
+    branches:
+      - develop
+      - r/*
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  file-upstream-studio-pr:
+    name: Create upstream studio PR to incorporate build
+    if: github.repository_owner == 'opencast'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # For the release
+      pull-requests: write  # For the PR in the upstream repo
+
+    steps:
+      - name: Prepare git
+        run: |
+          git config --global user.name "Studio Commit Bot"
+          git config --global user.email "cloud@opencast.org"
+
+      - name: Prepare GitHub SSH key
+        env:
+          DEPLOY_KEY: ${{ secrets.MODULE_PR_DEPLOY_KEY }}
+        run: |
+          install -dm 700 ~/.ssh/
+          echo "${DEPLOY_KEY}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+      - name: Clone upstream repository
+        run: |
+          git clone -b ${{ github.ref_name }} "git@github.com:${{ github.repository_owner }}/opencast.git" opencast
+          cd opencast
+          git checkout -b t/studio-${{ github.ref_name }}
+
+      - name: Update the studio submodule
+        working-directory: opencast
+        run: |
+          # Note: This could be a race condition in that rapid submodule pushes can trigger multiple PRs in short order
+          # and we don't have a guarantee that the update triggered by commit A does not end up finding commit B
+          # We are going to ignore this possibility since we almost universally want the *latest* commit, though this
+          # could end up causing the commit message, and the actual submodule hash to differ.
+          git submodule update --init --remote modules/studio
+          git add modules/studio
+          git commit -m "Updating studio to ${{ github.sha }}"
+          # This token is an account wide token which allows creation of PRs and pushes.
+          echo "${{ secrets.MODULE_PR_TOKEN }}" > token.txt
+          gh auth login --with-token < token.txt
+          export CURRENT_PR=$(gh pr list -R ${{ github.repository_owner }}/opencast --head t/studio-${{ github.ref_name }} --json number --jq '.[].number')
+          if [ -n "$CURRENT_PR" ]; then
+            gh pr edit $CURRENT_PR \
+              --body "Updating Opencast ${{ needs.detect-repo-owner.outputs.branch }} studio module to [${{ github.sha }}](https://github.com/${{ github.repository_owner }}/studio/commit/${{ github.sha }})" \
+              -R ${{ github.repository_owner }}/opencast
+            git push origin t/studio-${{ github.ref_name }} --force
+          else
+            gh pr create \
+              --title "Update ${{ needs.detect-repo-owner.outputs.branch }} Studio" \
+              --body "Updating Opencast ${{ needs.detect-repo-owner.outputs.branch }} Studio module to [${{ github.sha }}](https://github.com/${{ github.repository_owner }}/studio/commit/${{ github.sha }})" \
+              --head=${{ github.repository_owner }}:t/studio-${{ github.ref_name }} \
+              --base ${{ github.ref_name }} \
+              -R ${{ github.repository_owner }}/opencast
+              #FIXME: fine grained PATs can't apply labels
+              #FIXME: classic PATs don't have the permissions because the PR isn't in an opencastproject (the user) repo
+              #--label studio --label maintenance \
+          fi


### PR DESCRIPTION
This PR replaces the references to the `main` branch with appropriate release branches.  This is in relation to https://github.com/opencast/opencast/issues/7220.  While we don't see much in the way of development here, I've also added automated PR filing on release branch (or develop) change.
