### PR TITLE
Sort language selector

### DIFF
--- a/src/i18n/languages.tsx
+++ b/src/i18n/languages.tsx
@@ -1,15 +1,16 @@
+// Sort by `long` via `Intl.Collator("en")`
 const languages = [
-  { short: "en", long: "English", rtl: false },
-  { short: "de", long: "Deutsch", rtl: false },
-  { short: "nl", long: "Nederlands", rtl: false },
-  { short: "es", long: "Español", rtl: false },
-  { short: "fa", long: "فارسی", rtl: true },
-  { short: "fr", long: "Français", rtl: false },
-  { short: "sl", long: "Slovenščina", rtl: false },
-  { short: "zh", long: "简体中文", rtl: false },
   { short: "ca", long: "Català", rtl: false },
-  { short: "it", long: "Italiano", rtl: false },
   { short: "da", long: "Dansk", rtl: false },
+  { short: "de", long: "Deutsch", rtl: false },
+  { short: "en", long: "English", rtl: false },
+  { short: "es", long: "Español", rtl: false },
+  { short: "fr", long: "Français", rtl: false },
+  { short: "it", long: "Italiano", rtl: false },
+  { short: "nl", long: "Nederlands", rtl: false },
+  { short: "sl", long: "Slovenščina", rtl: false },
+  { short: "fa", long: "فارسی", rtl: true },
+  { short: "zh", long: "简体中文", rtl: false },
 ];
 
 export default languages;


### PR DESCRIPTION
The previous order was quite random, languages were just added to the end of the list. This makes it harder to find the language you want. This is now sorted by `Intl.Collator("en")`, which seems to be common practice.