### PR TITLE
Fix/workaround inflated video duration (Safari only)

### DIFF
--- a/src/steps/recording/recorder.tsx
+++ b/src/steps/recording/recorder.tsx
@@ -1,6 +1,6 @@
 import fixWebmDuration from "webm-duration-fix";
 import { Settings } from "../../settings";
-import { dimensionsOf } from "../../util";
+import { dimensionsOf, onSafari } from "../../util";
 
 
 export type OnStopCallback = (args: {
@@ -14,6 +14,7 @@ export default class Recorder {
   #recorder: MediaRecorder;
   #data: Blob[] = [];
   #dimensions: [number, number] | null;
+  #silentAudioCtx: AudioContext | null = null;
 
   onStop: OnStopCallback;
 
@@ -43,6 +44,20 @@ export default class Recorder {
 
     this.#dimensions = dimensionsOf(stream);
     this.onStop = onStop;
+
+    // Safari workaround: when recording a video-only stream (no audio
+    // tracks), Safari produces a file whose duration is roughly doubled.
+    // Adding a silent audio track prevents this.
+    if (onSafari() && stream.getAudioTracks().length === 0) {
+      const audioCtx = new AudioContext();
+      this.#silentAudioCtx = audioCtx;
+      const dest = audioCtx.createMediaStreamDestination();
+      const src = audioCtx.createConstantSource();
+      src.offset.value = 0;
+      src.connect(dest);
+      src.start();
+      stream = new MediaStream([...stream.getVideoTracks(), ...dest.stream.getAudioTracks()]);
+    }
 
     const videoBitsPerSecond = settings?.videoBitrate;
     this.#recorder = new MediaRecorder(stream, { mimeType, videoBitsPerSecond });
@@ -78,6 +93,8 @@ export default class Recorder {
     const url = URL.createObjectURL(media);
 
     this.#reset();
+    this.#silentAudioCtx?.close();
+    this.#silentAudioCtx = null;
 
     this.onStop?.({ url, media, mimeType, dimensions: this.#dimensions });
   };


### PR DESCRIPTION
Safari has an annoying bug where recordings without audio tracks will produce mp4s with broken duration metadata. This results in videos that are roughly double the correct duration.
Adding a fake silent audio track helps Safari to recognize the correct duration by cross checking both tracks.

However this fix comes with the downside that non-audio recordings now have that fake audio track baked in, as it can't be easily removed without reprocessing. My guess is that this is fine, but it would obviously be nicer if that weren't the case.

I don't like this workaround, it's weird. At least it is scoped purely to Safari, and from what I can tell it is the simplest solution for this issue. I have looked at other web-based recording tools in Safari to see how they deal with this, but they either
- (a) don't support Safari at all, or
- (b) also appear to be featuring a silent audio track

The ones that are open source are in the first category, proprietary ones in the second, so unfortunately I couldn't look at their code.