### PR TITLE
Ensure node version matches parent pom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: Build & test
 
 on: [pull_request, push]
 
+
+env:
+  NODE_VERSION: 24
+
 jobs:
   main:
     # We don't build PRs from dependabot, as we run everything for its branch push anyway
@@ -11,7 +15,13 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-node@v6
       with:
-        node-version: 17
+        node-version: ${{ env.NODE_VERSION }}
+    - name: Ensure our node version matches the main repo's version
+      run: |
+        [[ "$(curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.ref_name }}/pom.xml | \
+            grep node.version | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)" == "$NODE_VERSION" ]] \
+        && exit 0 \
+        || (echo "Node version does not match"; exit 1)
     - run: npm ci
     - run: npx eslint src --max-warnings=0
     - run: npm run build:dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,14 @@ jobs:
       with:
         node-version: ${{ env.NODE_VERSION }}
     - name: Ensure our node version matches the main repo's version
+      if: github.event_name == 'pull_request'
+      run: |
+        [[ "$(curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.base_ref }}/pom.xml | \
+            grep node.version | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)" == "$NODE_VERSION" ]] \
+        && exit 0 \
+        || (echo "Node version does not match"; exit 1)
+    - name: Ensure our node version matches the main repo's version
+      if: github.event_name == 'push'
       run: |
         [[ "$(curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.ref_name }}/pom.xml | \
             grep node.version | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)" == "$NODE_VERSION" ]] \

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,6 +5,9 @@ on:
 
 name: Create release draft
 
+env:
+  NODE_VERSION: 24
+
 jobs:
   build:
     name: Create release from tag
@@ -14,10 +17,17 @@ jobs:
       - name: checkout code
         uses: actions/checkout@v6
 
-      - name: use node.js 17.x
+      - name: use node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 17
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Ensure our node version matches the main repo's version
+        run: |
+          [[ "$(curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.ref_name }}/pom.xml | \
+              grep node.version | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)" == "$NODE_VERSION" ]] \
+          && exit 0 \
+          || (echo "Node version does not match"; exit 1)
 
       - name: create release tarball
         run: echo 'y' | ./.github/create-release.sh

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,6 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <nodejs.version>v17.9.1</nodejs.version>
-    <!--<ui.include.resource>/studio=-build/</ui.include.resource>-->
   </properties>
   <profiles>
     <profile>
@@ -28,7 +26,7 @@
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
             <configuration>
-              <nodeVersion>${nodejs.version}</nodeVersion>
+              <nodeVersion>${node.version}</nodeVersion>
               <environmentVariables>
                 <PUBLIC_PATH>/studio</PUBLIC_PATH>
                 <SETTINGS_PATH>/ui/config/studio/settings.toml</SETTINGS_PATH>
@@ -102,7 +100,7 @@
             <groupId>com.github.eirslett</groupId>
             <artifactId>frontend-maven-plugin</artifactId>
             <configuration>
-              <nodeVersion>${nodejs.version}</nodeVersion>
+              <nodeVersion>${node.version}</nodeVersion>
               <installDirectory>target</installDirectory>
               <environmentVariables>
                 <PUBLIC_PATH>/studio</PUBLIC_PATH>


### PR DESCRIPTION
This PR checks to see that *our* node version matches the upstream parent's pom's version.

This has the side effect of updating the current version of node in use, especially once https://github.com/opencast/opencast/pull/7636 is merged.
